### PR TITLE
Cleanup tspan conversions

### DIFF
--- a/src/Algorithms/GLGM06/post.jl
+++ b/src/Algorithms/GLGM06/post.jl
@@ -3,6 +3,7 @@ function post(alg::GLGM06, ivp::IVP{<:AbstractContinuousSystem}, tspan; kwargs..
 
     @unpack δ, approx_model, max_order, static, dim, ngens, preallocate, reduction_method = alg
 
+    # TODO move up to main solve function
     if haskey(kwargs, :NSTEPS)
         NSTEPS = kwargs[:NSTEPS]
         T = NSTEPS * δ


### PR DESCRIPTION
Closes #68.

- `_promote_tspan` returns a `TimeInterval` (in the future we may add a time parameter to that type, such that it's of the form `IA.Interva{N}`)
- the case where the time span is defined a posteriori is solved by using `IntervalArithmetic.emptyinterval()` (which is also an interval, so the function is type-stable)
- dispatch on `solve` directly for systems with clocked linear dynamics 