### PR TITLE
Lazily shift flowpipes in time triggered problems

### DIFF
--- a/docs/src/man/hybrid.md
+++ b/docs/src/man/hybrid.md
@@ -1,3 +1,15 @@
-# Hybrid differential equations
+# Hybrid systems
 
-- bouncing ball
+## Introduction
+
+
+Our running example is the *bouncing ball* model; although it is a very hybrid automaton, it can be used to introduce the main notions involved in hybrid systems reachability.
+
+
+## Clocked linear dynamics
+
+So far we have focused on transitions that involve "spatial" variables.
+If the system under consideration has transitions governed by time variables,
+i.e. by variables whose dynamics are of the form ``t' = 1``, then decoupling the
+spatial variables with the clock variables gives a computational advantage.
+We refer to [[HG19]].

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -244,6 +244,23 @@ a reference, do not hesitate to contact us by email, or open an issue. Sorting i
 
 ---
 
+#### [HG19]
+
+- el Hakim, Viktorio S., and Marco JG Bekooij. [*Reachability Analysis of Hybrid Automata with Clocked Linear Dynamics.*](https://dl.acm.org/doi/abs/10.1145/3323439.3323980).
+  Proceedings of the 22nd International Workshop on Software and Compilers for Embedded Systems. 2019.
+
+```
+@inproceedings{el2019reachability,
+  title={Reachability Analysis of Hybrid Automata with Clocked Linear Dynamics},
+  author={el Hakim, Viktorio S and Bekooij, Marco JG},
+  booktitle={Proceedings of the 22nd International Workshop on Software and Compilers for Embedded Systems},
+  pages={27--36},
+  year={2019}
+}
+```
+
+---
+
 #### [JOL]
 
 - Joldes, M. M. (2011). [*Approximations polynomiales rigoureuses et applications*](https://www.theses.fr/2011ENSL0655/document).

--- a/src/Algorithms/ASB07/ASB07.jl
+++ b/src/Algorithms/ASB07/ASB07.jl
@@ -80,31 +80,12 @@ function rsetrep(alg::ASB07{N, AM, RM, Val{false}}) where {N, AM, RM}
     RT = ReachSet{N, Zonotope{N, Vector{N}, Matrix{N}}}
 end
 
-# TODO add static case
-#=
-function rsetrep(alg::ASB07{N}) where {N}
-    if alg.static == Val{false} # TODO use type param
-        RT = ReachSet{N, Zonotope{N, Vector{N}, Matrix{N}}}
-    else
-        error("not implemented yet")
-        #=
-        @assert !ismissing(alg.dim) "the `static` option requires that the dimension " *
-        "field of this algorithm is given, but it is $(alg.dim)"
-
-        @assert !ismissing(alg.ngens) "the `static` option requires that the number of " *
-        "generators is known, but it is $(alg.ngens)"
-
-        n = alg.dim # dimension
-        p = alg.ngens # number of generators
-        VT = SVector{n, N}
-        MT = SMatrix{n, p, N, n*p}
-        ZT = Zonotope{N, VT, MT}
-        RT = ReachSet{N, ZT}
-        =#
-    end
-    return RT
+function rsetrep(alg::ASB07{N, AM, RM, S, R, Val{n}, Val{p}}) where {N, AM, RM, S, R, n, p}
+    VT = SVector{n, N}
+    MT = SMatrix{n, p, N, n*p}
+    ZT = Zonotope{N, VT, MT}
+    RT = ReachSet{N, ZT}
 end
-=#
 
 include("post.jl")
 include("reach_homog.jl")

--- a/src/Algorithms/ASB07/ASB07.jl
+++ b/src/Algorithms/ASB07/ASB07.jl
@@ -47,13 +47,15 @@ These methods are discussed at length in the dissertation [[ALT10]](@ref).
 Regarding the zonotope order reduction methods, we refer to [[COMB03]](@ref),
 [[GIR05]](@ref) and the review article [[YS18]](@ref).
 """
-struct ASB07{N, AM, RM, S, R} <: AbstractContinuousPost
+struct ASB07{N, AM, RM, S, R, D, NG} <: AbstractContinuousPost
     δ::N
     approx_model::AM
     max_order::Int
     reduction_method::RM
     static::S
     recursive::R
+    dim::D
+    ngens::NG
 end
 
 # convenience constructor using symbols
@@ -62,9 +64,13 @@ function ASB07(; δ::N,
                max_order::Int=5,
                reduction_method::RM=GIR05(),
                static::Bool=false,
-               recursive::Bool=true) where {N, AM, RM}
-    #n = !ismissing(dim) ? Val(dim) : dim
-    return ASB07(δ, approx_model, max_order, reduction_method, Val(static), Val(recursive))
+               recursive::Bool=true,
+               dim::Union{Int, Missing}=missing,
+               ngens::Union{Int, Missing}=missing) where {N, AM, RM}
+
+    n = ismissing(dim) ? missing : Val(dim)
+    p = ismissing(ngens) ? missing : Val(ngens)
+    return ASB07(δ, approx_model, max_order, reduction_method, Val(static), Val(recursive), n, p)
 end
 
 step_size(alg::ASB07) = alg.δ
@@ -74,7 +80,7 @@ function rsetrep(alg::ASB07{N, AM, RM, Val{false}}) where {N, AM, RM}
     RT = ReachSet{N, Zonotope{N, Vector{N}, Matrix{N}}}
 end
 
-# TODO add stati case
+# TODO add static case
 #=
 function rsetrep(alg::ASB07{N}) where {N}
     if alg.static == Val{false} # TODO use type param

--- a/src/Algorithms/ASB07/post.jl
+++ b/src/Algorithms/ASB07/post.jl
@@ -1,6 +1,6 @@
 function post(alg::ASB07, ivp::IVP{<:AbstractContinuousSystem}, tspan; kwargs...)
 
-    @unpack δ, approx_model, max_order, static, recursive, reduction_method = alg
+    @unpack δ, approx_model, max_order, static, recursive, reduction_method, dim, ngens = alg
 
     if haskey(kwargs, :NSTEPS)
         NSTEPS = kwargs[:NSTEPS]
@@ -31,7 +31,7 @@ function post(alg::ASB07, ivp::IVP{<:AbstractContinuousSystem}, tspan; kwargs...
 
     # reconvert the set of initial states and state matrix, if needed
     #static = haskey(kwargs, :static) ? kwargs[:static] : static # TODO review kwargs vs alg args precedence
-    Ω0 = _reconvert(Ω0, static, dim, ngens) # TODO: add dim + generators to the type
+    Ω0 = _reconvert(Ω0, static, dim, ngens)
     Φ = _reconvert(Φ, static, dim)
 
     # preallocate output flowpipe

--- a/src/Algorithms/ASB07/post.jl
+++ b/src/Algorithms/ASB07/post.jl
@@ -1,6 +1,6 @@
 function post(alg::ASB07, ivp::IVP{<:AbstractContinuousSystem}, tspan; kwargs...)
 
-    @unpack δ, approx_model, max_order, static, recursive, reduction_method, dim, ngens = alg
+    @unpack δ, approx_model, max_order, reduction_method, static, recursive, dim, ngens = alg
 
     if haskey(kwargs, :NSTEPS)
         NSTEPS = kwargs[:NSTEPS]

--- a/src/Algorithms/BOX/BOX.jl
+++ b/src/Algorithms/BOX/BOX.jl
@@ -68,15 +68,14 @@ end
 step_size(alg::BOX) = alg.δ
 numtype(::BOX{N}) where {N} = N
 
-function rsetrep(alg::BOX{N}) where {N}
-    if !alg.static
-        VT = Vector{N}
-    else
-        n = alg.dim
-        VT = SVector{n, N}
-    end
+function rsetrep(::BOX{N, AM, Val{false}, D, R}) where {N, AM, D, R}
+    VT = Vector{N}
     RT = ReachSet{N, Hyperrectangle{N, VT, VT}}
-    return RT
+end
+
+function rsetrep(::BOX{N, AM, Val{true}, Val{n}, R}) where {N, AM, n, R}
+    VT = SVector{n, N}
+    RT = ReachSet{N, Hyperrectangle{N, VT, VT}}
 end
 
 include("post.jl")

--- a/src/Algorithms/GLGM06/GLGM06.jl
+++ b/src/Algorithms/GLGM06/GLGM06.jl
@@ -99,27 +99,6 @@ function rsetrep(alg::GLGM06{N, AM, Val{true}, Val{n}, Val{p}}) where {N, AM, n,
     RT = ReachSet{N, ZT}
 end
 
-#=
-    if alg.static == Val{false} # TODO use type param
-        RT = ReachSet{N, Zonotope{N, Vector{N}, Matrix{N}}}
-    else
-        @assert !ismissing(alg.dim) "the `static` option requires that the dimension " *
-        "field of this algorithm is given, but it is $(alg.dim)"
-
-        @assert !ismissing(alg.ngens) "the `static` option requires that the number of " *
-        "generators is known, but it is $(alg.ngens)"
-
-        n = alg.dim # dimension
-        p = alg.ngens # number of generators
-        VT = SVector{n, N}
-        MT = SMatrix{n, p, N, n*p}
-        ZT = Zonotope{N, VT, MT}
-        RT = ReachSet{N, ZT}
-    end
-    return RT
-end
-=#
-
 include("post.jl")
 include("reach_homog.jl")
 include("reach_inhomog.jl")

--- a/src/Algorithms/GLGM06/GLGM06.jl
+++ b/src/Algorithms/GLGM06/GLGM06.jl
@@ -92,7 +92,13 @@ function rsetrep(alg::GLGM06{N, AM, Val{false}}) where {N, AM}
     RT = ReachSet{N, Zonotope{N, Vector{N}, Matrix{N}}}
 end
 
-# TODO add rsetrep for static case
+function rsetrep(alg::GLGM06{N, AM, Val{true}, Val{n}, Val{p}}) where {N, AM, n, p}
+    VT = SVector{n, N}
+    MT = SMatrix{n, p, N, n*p}
+    ZT = Zonotope{N, VT, MT}
+    RT = ReachSet{N, ZT}
+end
+
 #=
     if alg.static == Val{false} # TODO use type param
         RT = ReachSet{N, Zonotope{N, Vector{N}, Matrix{N}}}

--- a/src/Algorithms/GLGM06/GLGM06.jl
+++ b/src/Algorithms/GLGM06/GLGM06.jl
@@ -78,6 +78,7 @@ function GLGM06(; δ::N,
                ngens::Union{Int, Missing}=missing,
                preallocate::Bool=true,
                reduction_method::RM=GIR05()) where {N, AM, RM}
+
     n = ismissing(dim) ? missing : Val(dim)
     p = ismissing(ngens) ? missing : Val(ngens)
     return GLGM06(δ, approx_model, max_order, Val(static), n, p,

--- a/src/Algorithms/GLGM06/GLGM06.jl
+++ b/src/Algorithms/GLGM06/GLGM06.jl
@@ -79,6 +79,8 @@ function GLGM06(; δ::N,
                preallocate::Bool=true,
                reduction_method::RM=GIR05()) where {N, AM, RM}
 
+    # algorithm with "preallocation" is only defined for the non-static case
+    preallocate = !static
     n = ismissing(dim) ? missing : Val(dim)
     p = ismissing(ngens) ? missing : Val(ngens)
     return GLGM06(δ, approx_model, max_order, Val(static), n, p,

--- a/src/Flowpipes/flowpipes.jl
+++ b/src/Flowpipes/flowpipes.jl
@@ -386,13 +386,13 @@ end
 @inline time_shift(fp::ShiftedFlowpipe) = fp.t0
 
 # time domain interface
-@inline tstart(fp::ShiftedFlowpipe) = tstart(first(fp)) + time_shift(fp)
-@inline tend(fp::ShiftedFlowpipe) = tend(last(fp)) + time_shift(fp)
+@inline tstart(fp::ShiftedFlowpipe) = tstart(first(fp)) + fp.t0
+@inline tend(fp::ShiftedFlowpipe) = tend(last(fp)) + fp.t0
 @inline tspan(fp::ShiftedFlowpipe) = TimeInterval(tstart(fp), tend(fp))
 
-#@inline tstart(fp::ShiftedFlowpipe, i::Int) = tstart(fp.F[i]) + fp.t0
-#@inline tend(fp::ShiftedFlowpipe, i::Int) = tend(fp.F[i]) + time_shift(fp)
-#@inline tspan(fp::ShiftedFlowpipe, i::Int) = TimeInterval(tstart(fp), tend(fp))
+@inline tstart(fp::ShiftedFlowpipe, i::Int) = tstart(fp.F[i]) + fp.t0
+@inline tend(fp::ShiftedFlowpipe, i::Int) = tend(fp.F[i]) + fp.t0
+@inline tspan(fp::ShiftedFlowpipe, i::Int) = TimeInterval(tstart(fp), tend(fp))
 
 # TODO use interface?
 project(fp::ShiftedFlowpipe, vars::AbstractVector) = project(fp, Tuple(vars))

--- a/src/Flowpipes/flowpipes.jl
+++ b/src/Flowpipes/flowpipes.jl
@@ -314,6 +314,7 @@ end
 
 project(fp::Flowpipe, vars::AbstractVector) = project(fp, Tuple(vars))
 project(fp::Flowpipe; vars) = project(fp, Tuple(vars))
+project(fp::Flowpipe, i::Int, vars) = project(fp[i], vars)
 
 """
     shift(fp::Flowpipe{N, ReachSet{N, ST}}, t0::Number) where {N, ST}
@@ -392,6 +393,42 @@ end
 #@inline tstart(fp::ShiftedFlowpipe, i::Int) = tstart(fp.F[i]) + fp.t0
 #@inline tend(fp::ShiftedFlowpipe, i::Int) = tend(fp.F[i]) + time_shift(fp)
 #@inline tspan(fp::ShiftedFlowpipe, i::Int) = TimeInterval(tstart(fp), tend(fp))
+
+# TODO use interface?
+project(fp::ShiftedFlowpipe, vars::AbstractVector) = project(fp, Tuple(vars))
+project(fp::ShiftedFlowpipe; vars) = project(fp, Tuple(vars))
+
+function project(fp::ShiftedFlowpipe, vars::NTuple{D, T}) where {D, T<:Integer}
+    Xk = array(fp)
+    # TODO: use projection of the reachsets
+    if 0 ∈ vars # projection includes "time"
+        # we shift the vars indices by one as we take the Cartesian prod with the time spans
+        aux = vars .+ 1
+        t0 = time_shift(fp)
+        return map(X -> _project(convert(Interval, tspan(X) + t0) × set(X), aux), Xk)
+    else
+        return map(X -> _project(set(X), vars), Xk)
+    end
+end
+
+# this method is analogue to project(::AbstractLazyReachSet, vars; check_vars=true)
+# TODO add check_vars ?
+function project(fp::ShiftedFlowpipe, i::Int, vars::NTuple{D, M}) where {D, M<:Integer}
+    t0 = time_shift(fp)
+    R = fp[i]
+    if 0 ∈ vars
+        # if the projection involves "time", we shift the vars indices by one as
+        # we will take the Cartesian product of the reach-set with the time interval
+        aux = vars .+ 1
+
+        Δt = convert(Interval, tspan(R) + t0)
+        proj =  _project(Δt × set(R), aux)
+    else
+        proj = _project(set(R), vars)
+    end
+
+    return SparseReachSet(proj, tspan(R) + t0, vars)
+end
 
 # =====================================
 # Flowpipe composition with a lazy map

--- a/src/Flowpipes/flowpipes.jl
+++ b/src/Flowpipes/flowpipes.jl
@@ -472,6 +472,12 @@ function HybridFlowpipe(Fk::Vector{FT}, ext::Dict{Symbol, Any}) where {N, RT<:Ab
     return HybridFlowpipe{N, RT, FT}(voa, ext)
 end
 
+function HybridFlowpipe(Fk::Vector{SFT}) where {N, RT, FT<:Flowpipe{N, RT}, NT<:Number, SFT<:ShiftedFlowpipe{FT, NT}}
+    voa = VectorOfArray{RT, 2, Vector{SFT}}(Fk)
+    ext = Dict{Symbol, Any}()
+    return HybridFlowpipe{N, RT, SFT}(voa, ext)
+end
+
 # interface functions
 array(fp::HybridFlowpipe) = fp.Fk
 flowpipe(fp::HybridFlowpipe) = fp

--- a/src/Flowpipes/flowpipes.jl
+++ b/src/Flowpipes/flowpipes.jl
@@ -389,6 +389,10 @@ end
 @inline tend(fp::ShiftedFlowpipe) = tend(last(fp)) + time_shift(fp)
 @inline tspan(fp::ShiftedFlowpipe) = TimeInterval(tstart(fp), tend(fp))
 
+#@inline tstart(fp::ShiftedFlowpipe, i::Int) = tstart(fp.F[i]) + fp.t0
+#@inline tend(fp::ShiftedFlowpipe, i::Int) = tend(fp.F[i]) + time_shift(fp)
+#@inline tspan(fp::ShiftedFlowpipe, i::Int) = TimeInterval(tstart(fp), tend(fp))
+
 # =====================================
 # Flowpipe composition with a lazy map
 # =====================================

--- a/src/Flowpipes/recipes.jl
+++ b/src/Flowpipes/recipes.jl
@@ -459,8 +459,10 @@ end
         x = Vector{N}()
         y = Vector{N}()
         for F in flowpipe(sol)
-        for Ri in F
-            πRi = project(Ri, vars) # project the reach-set
+        for (i, Ri) in enumerate(F)
+            # NOTE: the following is needed to support ShiftedFlowpipe
+            # otherwise we would just to project(Ri, vars)
+            πRi = project(F, i, vars) # project the reach-set
             Xi = set(πRi) # extract the set representation
 
             if Xi isa Intersection

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -10,7 +10,7 @@ _reconvert(Ω0::Zonotope{N, Vector{N}, Matrix{N}}, static::Val{false}, dim, ngen
 _reconvert(Ω0::Zonotope{N, <:SVector, <:SMatrix}, static::Val{true}, dim) where {N} = Ω0
 
 # convert any zonotope to be represented wih regular arrays
-_reconvert(Ω0::Zonotope, static::Val{false}, dim) = Zonotope(Vector(Ω0.center), Matrix(Ω0.generators))
+_reconvert(Ω0::Zonotope, static::Val{false}, dim, ngens) = Zonotope(Vector(Ω0.center), Matrix(Ω0.generators))
 
 # convert any zonotope to be represented with static arrays
 function _reconvert(Ω0::Zonotope{N, VN, MN}, static::Val{true}, dim::Val{n}, ngens::Val{p}) where {N, VN, MN, n, p}
@@ -45,7 +45,6 @@ function _reconvert(Φ::AbstractMatrix{N}, static::Val{true}, dim::Val{n}) where
     #n = size(Φ, 1)
     Φ = SMatrix{n, n, N, n*n}(Φ)
 end
-
 
 function _reconvert(Φ::IntervalMatrix{N, IN, Matrix{IN}}, static::Val{true}, dim::Val{n}) where {N, IN, n}
     #n = size(Φ, 1)

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -23,7 +23,7 @@ function _reconvert(Ω0::Zonotope{N, VN, MN}, static::Val{true}, dim::Val{n}, ng
 
     elseif m < p
         # extend with zeros
-        Gext = hcat(SMatrix{n, m}(G), zeros(MMatrix{n, p-n, N}))
+        Gext = hcat(SMatrix{n, m}(G), zeros(MMatrix{n, p-m, N}))
         return Zonotope(c, Gext)
 
     else

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -282,25 +282,21 @@ function _overapproximate_interval_linear_map(Mc::AbstractMatrix{N},
     return Zonotope(c_oa, G_oa)
 end
 
-#=
-TODO : finish
-function _overapproximate_interval_linear_map(Mc::StaticArray{Tuple{q, n}, T, 2},
-                                              Ms::StaticArray{Tuple{q, n}, T, 2},
-                                              c::AbstractVector{N},
-                                              G::AbstractMatrix{N}) where {N, q, n, T}
-    m = size(G, 2) # number of generators
+function _overapproximate_interval_linear_map(Mc::SMatrix{n, n, N, LM},
+                                              Ms::SMatrix{n, n, N, LM},
+                                              c::SVector{n, N},
+                                              G::SMatrix{n, m, N, LG}) where {n, N, LM, m, LG}
     c_oa = Mc * c
     Ggens = Mc * G
 
-    dvec = zeros(MVector{n, N})
-    # TODO use abs.(c) ?
+    dvec = zeros(N, n)
     @inbounds for i in 1:n
         dvec[i] = abs(c[i])
         for j in 1:m
-            dvec[i, i] += abs(G[i, j])
+            dvec[i] += abs(G[i, j])
         end
     end
-    DV = zeros(MMatrix{n, n, N})
+    DV = zeros(MMatrix{n, n, N}) # NOTE: sole difference with regular arrays, may refactor
     α = Ms * dvec
     @inbounds for i in 1:n
         DV[i, i] = α[i]
@@ -308,7 +304,6 @@ function _overapproximate_interval_linear_map(Mc::StaticArray{Tuple{q, n}, T, 2}
     G_oa = hcat(Ggens, DV)
     return Zonotope(c_oa, G_oa)
 end
-=#
 
 function _split_fallback!(A::IntervalMatrix{T}, C, S) where {T}
     m, n = size(A)
@@ -384,7 +379,7 @@ _reduce_order(Z::Zonotope, r::Number, ::COMB03) = _reduce_order_COMB03(Z, r)
 
 # Implements zonotope order reduction method from [COMB03]
 # We follow the notation from [YS18]
-function _reduce_order_COMB03(Z::Zonotope{N, MN}, r::Number) where {N, MN}
+function _reduce_order_COMB03(Z::Zonotope{N}, r::Number) where {N}
     r >= 1 || throw(ArgumentError("the target order should be at least 1, but it is $r"))
     c = Z.center
     G = Z.generators
@@ -426,7 +421,7 @@ end
 
 # Implements zonotope order reduction method from [GIR05]
 # We follow the notation from [YS18]
-function _reduce_order_GIR05(Z::Zonotope{N, MN}, r::Number) where {N, MN}
+function _reduce_order_GIR05(Z::Zonotope{N}, r::Number) where {N}
     r >= 1 || throw(ArgumentError("the target order should be at least 1, but it is $r"))
     c = Z.center
     G = Z.generators
@@ -463,6 +458,47 @@ function _reduce_order_GIR05(Z::Zonotope{N, MN}, r::Number) where {N, MN}
     end
 
     K = G[:, indices[1:m]]
+    Gred = hcat(K, Lred)
+    return Zonotope(c, Gred)
+end
+
+# implementation for zonotopes using static arrays
+function _reduce_order_GIR05(Z::Zonotope{N, SVector{n, N}, SMatrix{n, p, N, LM}}, r::Number) where {N, n, p, LM}
+    r >= 1 || throw(ArgumentError("the target order should be at least 1, but it is $r"))
+    c = Z.center
+    G = Z.generators
+
+    # r is bigger than the order of Z => don't reduce
+    (r * n >= p) && return Z
+
+    # split Z into K and L, where K contains the most "representative" generators
+    # and L contains the generators that are reduced, Lred
+
+    # this algorithm sort generators by ||⋅||₁ - ||⋅||∞ difference
+    weights = zeros(N, p)
+    @inbounds for i in 1:p
+        v = view(G, :, i)
+        weights[i] = norm(v, 1) - norm(v, Inf)
+    end
+    indices = Vector{Int}(undef, p)
+    sortperm!(indices, weights, rev=true, initialized=false)
+
+    # the first m generators with greatest weight
+    m = floor(Int, n * (r - 1))
+
+    # compute interval hull of L
+    Lred = zeros(MMatrix{n, n, N})
+    @inbounds for i in 1:n
+        for j in indices[m+1:end]
+            Lred[i, i] += abs(G[i, j])
+        end
+    end
+
+    if isone(r)
+        return Zonotope(c, SMatrix{n, n}(Lred))
+    end
+
+    K = SMatrix{n, m}(view(G, :, indices[1:m]))
     Gred = hcat(K, Lred)
     return Zonotope(c, Gred)
 end

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -14,8 +14,22 @@ _reconvert(Ω0::Zonotope, static::Val{false}, dim, ngens) = Zonotope(Vector(Ω0.
 
 # convert any zonotope to be represented with static arrays
 function _reconvert(Ω0::Zonotope{N, VN, MN}, static::Val{true}, dim::Val{n}, ngens::Val{p}) where {N, VN, MN, n, p}
-    #n, p = size(Ω0.generators) # dimension and number of generators
-    Ω0 = Zonotope(SVector{n, N}(Ω0.center), SMatrix{n, p, N, n*p}(Ω0.generators))
+    G = Ω0.generators
+    m = size(G, 2)
+    c = SVector{n, N}(Ω0.center)
+
+    if m == p
+        return Zonotope(c, SMatrix{n, p}(G))
+
+    elseif m < p
+        # extend with zeros
+        Gext = hcat(SMatrix{n, m}(G), zeros(MMatrix{n, p-n, N}))
+        return Zonotope(c, Gext)
+
+    else
+        throw(ArgumentError("can't reconvert a zontope with $m generators to a " *
+                            "zonotope with $p generators; you should reduce it first"))
+    end
 end
 
 # no-op

--- a/src/Hybrid/time_triggered.jl
+++ b/src/Hybrid/time_triggered.jl
@@ -2,10 +2,28 @@
 # Hybrid systems with time-triggered transitions
 # ===============================================
 
+import MathematicalSystems: system, statedim, initial_state
+
+# particular HA where transitions are only time-triggered
 abstract type AbstractHybridAutomatonwithClockedLinearDynamics <: AbstractHybridSystem end
+
+# type alias
 const AHACLD = AbstractHybridAutomatonwithClockedLinearDynamics
 
-import MathematicalSystems: system, statedim, initial_state
+# abstarct supertype for the types of switching between discrete modes that are
+# handled by hybrid systems with time-triggeerd transitions
+abstract type AbstractSwitching end
+
+# deterministic switchings occur at prescribed time stamps, i.e. there is no jitter
+struct DeterministicSwitching <: AbstractSwitching end
+
+const deterministic_switching = DeterministicSwitching()
+
+# non-deterministic switchings may occur at any time between a prescribed interval,
+# i.e. there jitter is represented by an interval
+struct NonDeterministicSwitching <: AbstractSwitching end
+
+const nondeterministic_switching() = DeterministicSwitching()
 
 """
     HACLD1{T<:AbstractSystem, MT, N, J} <: AHACLD
@@ -14,10 +32,11 @@ Single-mode hybrid automaton with clocked linear dynamics.
 
 ### Fields
 
-- `sys`     -- system
-- `rmap`    -- reset map
-- `Tsample` -- sampling time
-- `ζ`       -- jitter
+- `sys`       -- system
+- `rmap`      -- reset map
+- `Tsample`   -- sampling time
+- `ζ`         -- jitter
+- `switching` -- (optional) value that
 
 ### Notes
 
@@ -26,52 +45,129 @@ This type is parametric in:
 - `T`  -- system type
 - `MT` -- type of the reset map
 - `N`  -- numeric type, applies to the sampling time and jitter
-- `J`  -- type associated to the jiter
+- `J`  -- type associated to the jitter
 
-The type associated to the jitter can be one of the following:
+The type associated to the jitter, `J`, can be one of the following:
 
 - `Missing`     -- no jitter, i.e. switchings are deterministic
-- `Number`      -- symetric jitter, i.e. switchings occure in the
+- `Number`      -- symetric jitter, i.e. non-deterministic switchings occur in the
                    intervals `[Tsample - ζ, Tsample + ζ]`
-- `IA.Interval` -- nonsymetric jitter, i.e. switchings occur in the intervals
+- `IA.Interval` -- nonsymetric jitter, i.e. non-deterministic switchings occur in the
                    intervals `[Tsample - inf(ζ), Tsample + sup(ζ)]`
 
 The following getter functions are available:
 
 - `initial_state`  -- initial state of the continuous mode
-- `jitter`         -- returns the jitter
-- `reset_map`      -- returns the reset map
-- `sampling_time`  -- retuns the sampling time
+- `jitter`         -- return the jitter
+- `reset_map`      -- return the reset map
+- `sampling_time`  -- return the sampling time
 - `statedim`       -- dimension of the state-space
-- `system`         -- returns the continuous mode
+- `system`         -- return the continuous mode
+- `switching`      -- return the type of switching
+
+Non-deterministic switching:
+
+ tstart       Ts-ζ⁻         tend
+ [-------------|-------------]
+
+In the following, suppose that the continuous post-operator has fixed step-size
+`δ > 0`. If `F` denotes the flowpipe, then
+
+  F[1]    F[2]    F[3]    F[4]    F[5]        F[k]
+[------][------][------][------][------]  ⋅ ⋅ ⋅ ⋅ ⋅ ⋅ ⋅ ⋅  [------]
+
+ `R = array(F)` denote the array of reach-sets time-span for reach reach-set is of the form:
+
+Similarly we compute tstart and tend for the supremum part Ts-ζ⁺
 """
-struct HACLD1{T<:AbstractSystem, MT, N, J} <: AHACLD
+struct HACLD1{T<:AbstractSystem, MT, N, J, S<:AbstractSwitching} <: AHACLD
     sys::T
     rmap::MT
     Tsample::N
     ζ::J
+    switching::S
 end
 
-# default constructor without jitter
-function HACLD1(sys::T, rmap::MT, Tsample::N) where {T, MT, N}
-    return HACLD1(sys, rmap, Tsample, missing)
-end
-
-initial_state(hs::HACLD1) = initial_state(hs.sys)
-jitter(hs::HACLD1{T, MT, N, Missing}) where {T, MT, N} = zero(N)
-jitter(hs::HACLD1{T, MT, N, J}) where {T, MT, N, J}  = hs.ζ
+# getter functions
+system(hs::HACLD1) = hs.sys
 reset_map(hs::HACLD1) = hs.rmap
 sampling_time(hs::HACLD1) = hs.Tsample
 statedim(hs::HACLD1) = statedim(hs.sys)
-system(hs::HACLD1) = hs.sys
+initial_state(hs::HACLD1) = initial_state(hs.sys)
+jitter(hs::HACLD1{T, MT, N, Missing}) where {T, MT, N} = TimeInterval(zero(N), zero(N))
+jitter(hs::HACLD1{T, MT, N, J}) where {T, MT, N, J}  = hs.ζ
+# TODO cleanup
+#jitter(hs::HACLD1{T, MT, N, J}) where {T, MT, N, J<:Real} = TimeInterval(-ζ, ζ)
+#jitter(hs::HACLD1{T, MT, N, J}) where {T, MT, N, J}  = _promote_tspan(hs.ζ)
+switching(::HACLD1{T, MT, N, J, S}) where {T, MT, N, J, S} = S
 
-# Non-deterministic switching diagram:
-#
-# tstart       Ts-ζ⁻         tend
-# [-------------|-------------]
-#
-# Similarly we compute tstart and tend for the supremum part Ts-ζ⁺
-function solve(ivp::IVP{<:HACLD1}, args...; kwargs...) # post(alg::AbstractContinuousPost, ivp::IVP{<:HACLD1}, tspan; kwargs...)
+# default constructor without jitter
+function HACLD1(sys::T, rmap::MT, Tsample::N) where {T, MT, N}
+    return HACLD1(sys, rmap, Tsample, missing, DeterministicSwitching())
+end
+
+# constructor when jitter is a real number
+function HACLD1(sys::T, rmap::MT, Tsample::N, ζ::J) where {T, MT, N, J<:Real}
+    if iszero(ζ)
+        switching = DeterministicSwitching()
+        ζint = TimeInterval(ζ, ζ)
+    else
+        switching = NonDeterministicSwitching()
+        ζint = TimeInterval(-ζ, ζ)
+    end
+    return HACLD1(sys, rmap, Tsample, ζint, switching)
+end
+
+# should be treated separately because IA.Interval <: Number
+function HACLD1(sys::T, rmap::MT, Tsample::N, ζ::J) where {T, MT, N, J<:IA.Interval}
+    return HACLD1(sys, rmap, Tsample, ζ, NonDeterministicSwitching())
+end
+
+# constructor when jitter is an inteval: check whether its diameter is zero or not
+# we promote ζ to accept tspan-like inputs (tuples, vectors, etc.)
+function HACLD1(sys::T, rmap::MT, Tsample::N, ζ::J) where {T, MT, N, J}
+    ζint = _promote_tspan(ζ)
+    switching = diam(ζint) > zero(N) ? NonDeterministicSwitching() : DeterministicSwitching()
+    return HACLD1(sys, rmap, Tsample, ζint, switching)
+end
+
+function _get_numsteps(Tsample, δ, ζ, ::NonDeterministicSwitching)
+    ζ⁻ = inf(ζ)
+    αlow = (Tsample + ζ⁻)/δ
+    NLOW = ceil(Int, αlow)
+
+    ζ⁺ = sup(ζ)
+    αhigh = (Tsample + ζ⁺)/δ
+    NHIGH = ceil(Int, αhigh)
+
+    return NLOW, NHIGH
+end
+
+function _get_numsteps(Tsample, δ, ζ, ::DeterministicSwitching)
+    αlow = Tsample / δ
+    NLOW = ceil(Int, αlow)
+    return NLOW, NLOW
+end
+
+function _get_max_jumps(tspan, Tsample, ζ, ::NonDeterministicSwitching)
+    # define max_jumps using the time horizon tspan
+    T = tend(tspan)
+    ζ⁺ = sup(ζ)
+    α = T / (Tsample - ζ⁺)
+    if α <= 0
+        error("inconsistent choice of parameters: T / (Tsample - ζ⁺) = $α, " *
+              "but it should be positive")
+    end
+    max_jumps = ceil(Int, α)
+end
+
+function _get_max_jumps(tspan, Tsample, ζ, ::DeterministicSwitching)
+    T = tend(tspan)
+    α = T / Tsample
+    max_jumps = ceil(Int, α)
+end
+
+function solve(ivp::IVP{<:HACLD1}, args...; kwargs...)
 
     # preliminary checks
     _check_dim(ivp)
@@ -87,103 +183,61 @@ function solve(ivp::IVP{<:HACLD1}, args...; kwargs...) # post(alg::AbstractConti
 
     X0 = initial_state(ivp)
     ha = system(ivp)
-    @unpack sys, rmap, Tsample, ζ = ha
+    @unpack sys, rmap, Tsample, ζ, switching = ha
     t0 = tstart(tspan)
     δ = step_size(alg)
 
+    # get maximum number of jumps
     if haskey(kwargs, :max_jumps)
         max_jumps = kwargs[:max_jumps]
-
     else
-        @assert tspan ≠ emptyinterval() "either the time span `tspan` or the maximum number " *
-                                        "of jumps `max_jumps` should be specified"
-
-        # define max_jumps using the time horizon tspan
-        T = tend(tspan)
-        α = T / (Tsample - ζ)
-        if α <= 0
-            error("inconsistent choice of parameters: T / (Tsample - ζ) = $α, " *
-                  "but it should be positive")
-        end
-        max_jumps = ceil(Int, α)
+        tspan ≠ emptyinterval() || throw(ArgumentError("either the time span `tspan` or the maximum number " *
+                                                       "of jumps `max_jumps` should be specified"))
+        max_jumps = _get_max_jumps(tspan, ζ, switching)
     end
 
-    # solve first interval
+    # number of steps for the continuous post
     prob = IVP(sys, X0)
-    αlow = (Tsample - ζ)/δ
-    NLOW = ceil(Int, αlow)
-
-
-    αhigh = (Tsample + ζ)/δ
-
-
-    NLOW, NHIGH = ()
-
-    if NLOW == 0
-        error("inconsistent choice of parameters: (Tsample - ζ)/δ = $αlow " *
-              "but it should be positive")
-<<<<<<< HEAD
-
-    sol = solve(prob, NSTEPS=NHIGH, alg=alg; kwargs...)
-=======
-    end
-    αhigh = (Tsample + ζ)/δ
-    NHIGH = ceil(Int, αhigh)
-    sol = post(alg, prob, ∅; NSTEPS=NHIGH)
->>>>>>> master
+    NLOW, NHIGH = _get_numsteps(Tsample, δ, ζ, switching)
+    @assert NLOW > 0 throw(ArgumentError("inconsistent choice of parameters"))
 
     # preallocate output vector of flowpipes
     N = numtype(alg)
     RT = rsetrep(alg)
+
     # VRT = SubArray{...}
     FT = Flowpipe{N, RT, Vector{RT}}
     out = Vector{FT}()
     sizehint!(out, max_jumps+1)
 
     @inbounds for k in 1:max_jumps+1
+        # solve next chunk
+        sol = post(alg, prob, emptyinterval(); NSTEPS=NHIGH)
 
-        # add time interval, 0 .. Tsample-ζ
+        # store flowpipe until first intersection with the guard
         aux = view(array(sol), 1:NLOW)
-
         push!(out, shift(Flowpipe(aux), t0))
 
+        # adjust initial time for next jump
         t0 += tstart(aux[end])
 
-        # Tsample-ζ .. Tsample+ζ
-        Xend = view(array(sol), NLOW:NHIGH) |> Flowpipe |> Convexify |> set
+        # get successors after discrete jump from Tsample - ζ⁻ .. Tsample + ζ⁺
+        Xend = _transition_successors(sol, NLOW, NHIGH, switching)
+
+        # apply reset map and instantiate new initial-value problem
         prob = IVP(sys, rmap(Xend))
-        sol = post(alg, prob, ∅; NSTEPS=NHIGH)
     end
 
     return ReachSolution(HybridFlowpipe(out), alg)
 end
 
-function _get_steps(Tsample, ζ::Number)
-
-    αlow = (Tsample - ζ)/δ
-    NLOW = ceil(Int, αlow)
-
-    αhigh = (Tsample + ζ)/δ
-    NHIGH = ceil(Int, αhigh)
-    return NLOW, NHIGH
+# deeterministic switching
+@inline function _transition_successors(sol, NLOW, NHIGH, ::DeterministicSwitching)
+    # in this scenario, NLOW == NHIGH
+    sol[NLOW] |> set
 end
 
-function _get_steps(Tsample, ζ)
-    ζ = TimeInterval(_promote_tspan(ζ))
-    αlow = (Tsample - ζ)/δ
-    NLOW = ceil(Int, αlow)
-
-    αhigh = (Tsample + ζ)/δ
-    NHIGH = ceil(Int, αhigh)
-    return NLOW, NHIGH
+# non-deterministic switching
+@inline function _transition_successors(sol, NLOW, NHIGH, ::NonDeterministicSwitching)
+    view(array(sol), NLOW:NHIGH) |> Flowpipe |> Convexify |> set
 end
-
-#=
-function _reach_HACLD1_no_jitter()
-
-end
-
-function _reach_HACLD1_with_jitter()
-
-end
-=#

--- a/src/Hybrid/time_triggered.jl
+++ b/src/Hybrid/time_triggered.jl
@@ -240,10 +240,8 @@ function solve(ivp::IVP{<:HACLD1}, args...; kwargs...)
     Xend = _transition_successors(sol, NLOW, NHIGH, switching)
 
     t0 += tstart(sol[NLOW])
-    println(t0)
+
     # adjust integer bounds for subsequent jumps
-    println("NLOW = $NLOW")
-    println("NHIGH = $NHIGH")
     NLOW += 1
     NHIGH += 1
 

--- a/src/Hybrid/time_triggered.jl
+++ b/src/Hybrid/time_triggered.jl
@@ -201,7 +201,7 @@ function solve(ivp::IVP{<:HACLD1}, args...; kwargs...)
     else
         tsp ≠ emptyinterval() || throw(ArgumentError("either the time span `tspan` or the maximum number " *
                                                        "of jumps `max_jumps` should be specified"))
-        max_jumps = _get_max_jumps(tsp, Tsampl, δ, ζ, switching)
+        max_jumps = _get_max_jumps(tsp, Tsample, δ, ζ, switching)
     end
 
     # number of steps for the continuous post

--- a/src/Hybrid/time_triggered.jl
+++ b/src/Hybrid/time_triggered.jl
@@ -262,7 +262,12 @@ end
     # in this scenario, NLOW == NHIGH most of the time
     # sol[NLOW] |> set
     # however, it may happen that NHIGH = NLOW + 1 if Tsample is a multiple of δ
-    view(array(sol), NLOW:NHIGH) |> Flowpipe |> Convexify |> set
+    if NLOW == NHIGH
+        # TODO: can we use dispach and remove this branch?
+        sol[NLOW] |> set
+    else
+        view(array(sol), NLOW:NHIGH) |> Flowpipe |> Convexify |> set
+    end
 end
 
 # non-deterministic switching

--- a/src/Initialization/exports.jl
+++ b/src/Initialization/exports.jl
@@ -54,4 +54,8 @@ export
     Shift,
 
 # Hybrid types
-    HACLD1
+    HACLD1,
+
+# Getter functions for hybrid systems
+    jitter,
+    switching

--- a/test/algorithms/ASB07.jl
+++ b/test/algorithms/ASB07.jl
@@ -40,8 +40,10 @@
 end
 
 @testset "ASB07 with time-triggered hybrid system" begin
-    prob = embrake_pv_1(ζ=0.0, Tsample=1e-4)
+    prob = embrake_pv_1(ζ=[-1e-8, 1e-7], Tsample=1e-4)
     sol = solve(prob, alg=ASB07(δ=1e-7, max_order=3), max_jumps=2)
+    @test dim(sol) == 4
+    @test flowpipe(sol) isa HybridFlowpipe
 end
 
 

--- a/test/models/hybrid/embrake.jl
+++ b/test/models/hybrid/embrake.jl
@@ -7,7 +7,7 @@ using SparseArrays
 
 # adapt default LazySets tolerances
 set_rtol(Float64, 1e-12)
-set_ztol(Float64, 1e-12)
+set_ztol(Float64, 1e-13)
 
 # model without parameter variation
 function embrake_no_pv(; Tsample=1.E-4, ζ=1e-6, x0=0.05)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test, ReachabilityAnalysis, StaticArrays
-using ReachabilityAnalysis: _isapprox, setrep, rsetrep
+
+using ReachabilityAnalysis: _isapprox, setrep, rsetrep,
+                           DeterministicSwitching, NonDeterministicSwitching
 
 # load test models
 include("models/linear/exponential1D.jl")


### PR DESCRIPTION
This PR is based on https://github.com/JuliaReach/ReachabilityAnalysis.jl/pull/134.
The purpose is to reduce allocations by lazily shifting the flowpipe along the time direction.

Some care should be taken when using `ShiftedFlowpipe`, because `tspan(F[i])` uses the incorrect method (at it can't dispatch on `typeof(F)`); we should use `tspan(F, i)` instead.

For BOX algorithm and statically sized arrays this gives my machine ~10x speedup with respect to `master`:

```julia
using Plots, BenchmarkTools
using Revise, ReachabilityAnalysis
include("/home/mforets/.julia/dev/ReachabilityAnalysis/test/models/hybrid/embrake.jl")
LazySets.deactivate_assertions()

prob = embrake_no_pv(ζ=0.0, Tsample=1e-4);
@time sol = solve(prob, alg=BOX(δ=1e-8, static=true, dim=4), max_jumps=1000);
@time sol = solve(prob, alg=BOX(δ=1e-8, static=true, dim=4), max_jumps=1000);

  0.635995 seconds (906.10 k allocations: 44.337 MiB)
  2.435276 seconds (229.89 k allocations: 1.385 GiB, 8.94% gc time)
```
