### PR TITLE
Fix indices of _get_numsteps

### DIFF
--- a/src/Hybrid/time_triggered.jl
+++ b/src/Hybrid/time_triggered.jl
@@ -133,14 +133,15 @@ end
 
 function _get_numsteps(Tsample, δ, ζ, ::DeterministicSwitching)
     αlow = Tsample / δ
-    NLOW = ceil(Int, αlow)
-    return NLOW, NLOW
+    NLOW = floor(Int, αlow)
+    NHIGH = ceil(Int, αlow)
+    return NLOW, NHIGH
 end
 
 function _get_numsteps(Tsample, δ, ζ, ::NonDeterministicSwitching)
     ζ⁻ = inf(ζ)
     αlow = (Tsample + ζ⁻)/δ
-    NLOW = ceil(Int, αlow)
+    NLOW = floor(Int, αlow)
 
     ζ⁺ = sup(ζ)
     αhigh = (Tsample + ζ⁺)/δ


### PR DESCRIPTION
Not sure what else has to change, but I think the old version was not correct.

It might be necessary to add +1 to both `NLOW` and `NHIGH` when accessing Julia arrays but that is a different issue.