### PR TITLE
Add adaptive abs_tol option for TMJets

### DIFF
--- a/src/Algorithms/TMJets/TMJets.jl
+++ b/src/Algorithms/TMJets/TMJets.jl
@@ -8,12 +8,13 @@ by Luis Benet and David Sanders in `TalorModels.jl`.
 
 - `max_steps` -- (optional, default: `2000`) maximum number of steps in the
                  validated integration ``x' = f(x)``
-- `abs_tol`   -- (optional, default: `1e-15`) absolute tolerance
+- `abs_tol`   -- (optional, default: `1e-10`) absolute tolerance
 - `orderT`    -- (optional, default: `8`) order of the Taylor model in time
-- `orderQ`    -- (optional, default: `2`) order of the Taylor models for jet
-                 transport variales
+- `orderQ`    -- (optional, default: `2`) order of the Taylor models for jet transport variables
 - `intersection_method` -- (optional, default: `ZonotopeEnclosure()`) defines the method to
                            compute the intersection of the taylor model flowpipe with the invariant
+- `adaptive`  -- (optional, default: `true`) if `true`, try decreasing the absolute
+                 tolerance each time step validation fails, until `min_abs_tol` is reached
 
 ### Notes
 
@@ -21,10 +22,12 @@ TODO: Add references.
 """
 @with_kw struct TMJets{N, DM<:AbstractTMDisjointnessMethod} <: AbstractContinuousPost
     max_steps::Int=2000
-    abs_tol::N=1e-15
+    abs_tol::N=1e-10
     orderT::Int=8
     orderQ::Int=2
     intersection_method::DM=ZonotopeEnclosure()
+    adaptive::Bool=true
+    min_abs_tol::N=1e-29
 end
 
 using TaylorModels: TaylorModelN

--- a/src/Algorithms/TMJets/post.jl
+++ b/src/Algorithms/TMJets/post.jl
@@ -1,8 +1,8 @@
 function post(alg::TMJets{N}, ivp::IVP{<:AbstractContinuousSystem}, tspan; kwargs...) where {N}
 
-    @unpack max_steps, abs_tol, orderT, orderQ, intersection_method = alg
+    @unpack max_steps, abs_tol, orderT, orderQ, intersection_method, adaptive, min_abs_tol = alg
 
-    # initial time and final tim
+    # initial time and final time
     t0 = tstart(tspan)
     T = tend(tspan)
 
@@ -30,9 +30,52 @@ function post(alg::TMJets{N}, ivp::IVP{<:AbstractContinuousSystem}, tspan; kwarg
     F = Vector{TaylorModelReachSet{N}}()
     sizehint!(F, max_steps)
 
-    F, tv, xv, xTM1v = _validated_integ!(F, f!, q0, δq0, t0, T, orderQ, orderT,
-                                         abs_tol, max_steps, X, intersection_method)
+    F, tv, xv, xTM1v, success, _t0 = _validated_integ!(F, f!, q0, δq0, t0, T, orderQ, orderT,
+                                      abs_tol, max_steps, X, intersection_method, adaptive)
 
-    ext = Dict{Symbol, Any}(:tv => tv, :xv => xv, :xTM1v => xTM1v) # keep Any or add the type param?
-    return Flowpipe(F, ext)
+    if success || !adaptive
+        ext = Dict{Symbol, Any}(:tv => tv, :xv => xv, :xTM1v => xTM1v) # keep Any or add the type param?
+        return Flowpipe(F, ext)
+    end
+
+    # save extra data, one vector per iteration
+    #tv_vec = Vector{typeof(tv)}()
+    #xv_vec = Vector{typeof(xv)}()
+    #xTM1v_vec = Vector{typeof(xTM1v)}()
+
+    #push!(tv_vec, tv)
+    #push!(xv_vec, xv)
+    #push!(xTM1v_vec, xTM1v)
+
+    while !success
+            # adapt the absolut tolerance
+            if abs_tol > min_abs_tol
+                abs_tol = abs_tol / 10
+            else
+                @warn("Minimum absolute tolerance, $min_abs_tol reached.")
+                ext = Dict{Symbol, Any}(:tv => tv, :xv => xv, :xTM1v => xTM1v) # keep Any or add the type param?
+                return Flowpipe(F, ext)
+            end
+
+            # new initial states
+            X0 = overapproximate(F[end], Zonotope) |> set
+            box_x0 = box_approximation(X0)
+            q0 = center(box_x0)
+            δq0 = IntervalBox(low(box_x0)-q0, high(box_x0)-q0)
+
+            # new flowpipe
+            Fk = Vector{TaylorModelReachSet{N}}()
+            sizehint!(Fk, max_steps)
+            Fk, tv, xv, xTM1v, success, _t0 = _validated_integ!(Fk, f!, q0, δq0, _t0, T, orderQ, orderT,
+                                                                abs_tol, max_steps, X, intersection_method, adaptive)
+
+            # append the new flowpipe to the accumulated flowpipe and extra data
+            append!(F, Fk)
+            #push!(tv_vec, copy(tv))
+            #push!(xv_vec, copy(xv))
+            #push!(xTM1v_vec, copy(xTM1v))
+    end
+    #ext = Dict{Symbol, Any}(:tv => tv_vec, :xv => xv_vec, :xTM1v => xTM1v_vec) # keep Any or add the type param?
+    #return Flowpipe(F, ext)
+    return Flowpipe(F)
 end


### PR DESCRIPTION
This PR the TMJets algorithm to refine the `abs_tol` automatically whenever the validation step (`remainder_taylorstep!`) fails. It allows solving relatively quickly those cases that would require a very small tolerance only for some part of the flowpipe.

In this proof of principle we monotonically decrease the abs_tol -- it just iterates calls to `validated_integ!`  with the last set from the previous flowpipe, adjusting the start time. Seems to me that working in the inner functions themselves gives a computational advantage, but i would leave that for later.

In the case of the Michaelis-Menten problem, for instance,  printing the abs_tol refinements gives:

```julia
start time t0 = 15.198728314843022, abs_tol = 1.0e-10
start time t0 = 53.384765311895436, abs_tol = 1.0000000000000001e-11
start time t0 = 58.82933543254129, abs_tol = 1.0000000000000002e-12
start time t0 = 63.613098867626526, abs_tol = 1.0000000000000002e-13
start time t0 = 70.55227235984829, abs_tol = 1.0000000000000002e-14
start time t0 = 74.28258270556347, abs_tol = 1.0e-15
start time t0 = 81.38795432377998, abs_tol = 1.0000000000000001e-16
start time t0 = 82.45733774144473, abs_tol = 1.0e-17
  1.942030 seconds (38.80 M allocations: 2.342 GiB, 21.16% gc time)
```


