### PR TITLE
Add location getter for flowpipes

### DIFF
--- a/src/Flowpipes/flowpipes.jl
+++ b/src/Flowpipes/flowpipes.jl
@@ -210,6 +210,9 @@ end
 # further setops
 LazySets.is_intersection_empty(F::AbstractFlowpipe, Y::LazySet) where {N} = all(X -> _is_intersection_empty(X, Y), array(F))
 
+# getter functions for hybrid systems
+location(F::AbstractFlowpipe) = get(F.ext, :loc_id, missing)
+
 # ================================
 # Flowpipes
 # ================================

--- a/src/Initialization/exports.jl
+++ b/src/Initialization/exports.jl
@@ -44,10 +44,6 @@ export
     sup_func, # TODO keep?
     setrep,
     rsetrep,
-    reset_map,
-    guard,
-    source_invariant,
-    target_invariant,
 
 # Concrete operations
     project,
@@ -65,4 +61,9 @@ export
 
 # Getter functions for hybrid systems
     jitter,
-    switching
+    switching,
+    location,
+    reset_map,
+    guard,
+    source_invariant,
+    target_invariant

--- a/test/hybrid.jl
+++ b/test/hybrid.jl
@@ -60,6 +60,9 @@ end
     prob_b = IVP(system(prob), [(X0, 1)]) # equivalent
     sol_a = solve(prob_a, tspan=3.0)
     sol_b = solve(prob_b, tspan=3.0)
+
+    # get vector of locations of each component flowpipe
+    @test location.(sol) == [1, 1]
 end
 
 @testset "Bouncing ball: nonlinear solvers" begin


### PR DESCRIPTION
With this PR, the function `location` can now be applied to flowpipes to retrieve the location associated to the flowpipe.