### PR TITLE
Add TemplateHullIntersection

### DIFF
--- a/src/Initialization/exports.jl
+++ b/src/Initialization/exports.jl
@@ -50,7 +50,7 @@ export
     shift,
     complement,
 
-# Lazy operations
+# Lazy operations on flowpipes
     Projection,
     Shift,
     Convexify,
@@ -66,4 +66,10 @@ export
     reset_map,
     guard,
     source_invariant,
-    target_invariant
+    target_invariant,
+
+# Algorithms for set operations
+    FallbackIntersection,
+    HRepIntersection,
+    BoxIntersection,
+    TemplateHullIntersection

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ include("solve.jl")
 include("reachsets.jl")
 include("flowpipes.jl")
 #include("traces.jl")
+include("setops.jl")
 
 include("algorithms/INT.jl")
 include("algorithms/BOX.jl")

--- a/test/setops.jl
+++ b/test/setops.jl
@@ -1,0 +1,10 @@
+@testset "Intersection strategies" begin
+    # default constructors
+    @test TemplateHullIntersection() == TemplateHullIntersection{Float64,Array{Float64,1},Missing}(missing)
+    @test TemplateHullIntersection{Float64, Vector{Float64}}() == TemplateHullIntersection{Float64,Array{Float64,1},Missing}(missing)
+    @test TemplateHullIntersection{Float64, SVector{2, Float64}}() == TemplateHullIntersection{Float64,SArray{Tuple{2},Float64,1,2},Missing}(missing)
+
+    # constructor passing the template
+    td = TemplateHullIntersection(BoxDirections(2))
+    @test setrep(td) == HPolytope{Float64,LazySets.Arrays.SingleEntryVector{Float64}}
+end


### PR DESCRIPTION
This method allows to evaluate X ∩ Y approximately using support function calls, using that the support function of X ∩ Y along direction d satisfies ρ(d, X ∩ Y) <= min(ρ(d, X), ρ(d, Y)). The template is a parameter of the type; if it's missing then we use the directions normal to X and Y.

![Screenshot from 2020-05-25 12-08-18](https://user-images.githubusercontent.com/12424594/82829545-e5b87280-9e89-11ea-8b44-ecafd38b699d.png)

![Screenshot from 2020-05-25 12-08-04](https://user-images.githubusercontent.com/12424594/82829548-e81acc80-9e89-11ea-8416-0fd2a3867914.png)

![Screenshot from 2020-05-25 13-17-06](https://user-images.githubusercontent.com/12424594/82829624-16001100-9e8a-11ea-9b01-7cd375ae4ac0.png)


![Screenshot from 2020-05-25 12-07-54](https://user-images.githubusercontent.com/12424594/82829655-2e702b80-9e8a-11ea-94d2-c0ed1dc2a078.png)

