### PR TITLE
Add (generic) template hull intersection for discrete transitions'

### DIFF
--- a/test/hybrid.jl
+++ b/test/hybrid.jl
@@ -63,6 +63,13 @@ end
 
     # get vector of locations of each component flowpipe
     @test location.(sol) == [1, 1]
+
+    # using GLGM06 + template hull intersection
+    dirs = PolarDirections(10)
+    sol = solve(prob, tspan=6.0, alg=GLGM06(δ=1e-2, max_order=10),
+                intersection_method=RA.TemplateHullIntersection(dirs),
+                clustering_method=RA.ZonotopeClustering(),
+                intersect_source_invariant=true
 end
 
 @testset "Bouncing ball: nonlinear solvers" begin


### PR DESCRIPTION
This method lets one use the `TemplateHullIntersection` method in discrete transitions. For the time being i just added the `apply` dispatch were all sets are polyhedral. (Note that `X` should also be annotated as polyhedral for the case of the `LGG09` algorithm which can partially compute the flowpipe).

In a comment i described the choice of the order of the operations for this implementation, which performs 1 concrete intersectin with HRep and 2 template intersections. There are certainly other ways of making this operation. In fact, Frehse & Ray's paper offer anther method which does only one template hull operation. We can do this in a follow up PR.
 
```julia
using Revise, ReachabilityAnalysis, Plots
const RA = ReachabilityAnalysis

include("/home/mforets/.julia/dev/ReachabilityAnalysis/test/models/hybrid/bouncing_ball.jl")

prob, _ = bouncing_ball();

# using GLGM06
prob, _ = bouncing_ball()
dirs = PolarDirections(100)
sol = solve(prob, tspan=6.0, alg=GLGM06(δ=1e-2, max_order=100),
            intersection_method=RA.TemplateHullIntersection(dirs),
            clustering_method=RA.ZonotopeClustering(),
            intersect_source_invariant=true)

plot(sol, vars=(1, 2))
```

![Screenshot from 2020-05-30 16-55-11](https://user-images.githubusercontent.com/12424594/83338006-5a2e4f80-a296-11ea-9b40-d446dda8514c.png)
