### PR TITLE
Add Van-der-Pol model to documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ deps/deps.jl
 
 docs/build/
 docs/site/
+docs/src/models/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -1,0 +1,26 @@
+import Literate
+using Literate: script, markdown, notebook
+
+src_dirs = [
+#     joinpath(@__DIR__, "..", "test", "models", "linear"),
+    joinpath(@__DIR__, "..", "test", "models", "nonlinear"),
+#     joinpath(@__DIR__, "..", "test", "models", "hybrid")
+]
+
+trgt_dir = joinpath(@__DIR__, "src", "models")
+mkpath(trgt_dir)
+
+for src_dir in src_dirs
+    for file in readdir(src_dir)
+        if endswith(file, ".jl")
+            src_path = abspath(joinpath(src_dir, file))
+            text = script(src_path, trgt_dir, credit=false)
+            code = strip(read(text, String))
+            mdpost(str) = replace(str, "@__CODE__" => code)
+            markdown(src_path, trgt_dir, postprocess=mdpost, credit=false)
+            notebook(src_path, trgt_dir, execute=true, credit=false)
+        else
+            @warn "ignoring $src_dir/$file"
+        end
+    end
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,9 @@ using Documenter, ReachabilityAnalysis
 DocMeta.setdocmeta!(ReachabilityAnalysis, :DocTestSetup,
                    :(using ReachabilityAnalysis); recursive=true)
 
+# generate Literate documentation
+include("generate.jl")
+
 makedocs(
     format = Documenter.HTML(prettyurls = haskey(ENV, "GITHUB_ACTIONS")), # disable for local builds
     sitename = "ReachabilityAnalysis.jl",
@@ -25,7 +28,8 @@ makedocs(
         "Applications" => Any["Electromechanic break" => "man/applications/embrake.md",
                               "Quadrotor altitude control" => "man/applications/quadrotor.md",
                               "Transmision line" => "man/applications/transmission_line.md",
-                              "Epidemic disease" => "man/applications/epidemic.md"],
+                              "Epidemic disease" => "man/applications/epidemic.md",
+                              "Van der Pol oscillator" => "models/vanderpol.md"],
                               # Other topics: car control, power systems stability.
         "Algorithms" => Any["ASB07" => "lib/algorithms/ASB07.md",
                             "BFFPSV18" => "lib/algorithms/BFFPSV18.md",

--- a/test/models/nonlinear/vanderpol.jl
+++ b/test/models/nonlinear/vanderpol.jl
@@ -1,9 +1,26 @@
-# =======================================
-# Van der Pol oscillator
-# #include("models/lotka_volterra.jl")
-# https://en.wikipedia.org/wiki/Van_der_Pol_oscillator
-# Number of state variables: 2
-# =======================================
+# # Van der Pol oscillator
+#md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](__NBVIEWER_ROOT_URL__/../vanderpol.ipynb)
+#
+#md # !!! note "Overview"
+#md #     system type: polynomial continuous system\
+#md #     state dimension: 2
+#
+# For more information on the model see
+# [Wikipedia](https://en.wikipedia.org/wiki/Van_der_Pol_oscillator).
+
+# ## Dynamics
+#
+# The dynamics of the Van der Pol oscillator are described as follows:
+#
+# ```math
+# \begin{aligned}
+#   \dot{x} &= y \\
+#   \dot{y} &= \mu (1 - x^2) y - x
+# \end{aligned}
+# ```
+# We consider the parameter ``μ = 1``.
+
+#!jl using ReachabilityAnalysis, Plots  #hide
 
 @taylorize function vanderPol!(dx, x, params, t)
     local μ = 1.0
@@ -12,31 +29,21 @@
     return dx
 end
 
-function vanderpol()
+# ## Initial-value problem
+
+function vanderpol()  #jl
+    ## set of initial states
     X0 = Hyperrectangle(low=[1.25, 2.35], high=[1.55, 2.45])
-    prob = @ivp(x' = vanderPol!(x), dim: 2, x(0) ∈ X0)
+#!jl     plot(X0)  #hide
+
+    #-
+
+    ## initial-value problem
+    ivp = @ivp(x' = vanderPol!(x), dim: 2, x(0) ∈ X0)
+
+    ## time horizon
     tspan = (0.0, 5.0)
 
-    return prob, tspan
-end
-
-#=
-OLD
-
-# check mode
-property = (t, x) -> x[2] <= 2.75
-sol = solve(P, T=7.0, property=property, alg)
-
-# test set representation option
-sol = solve(P, T=7.0, setrep=:Hyperrectangle, alg)
-@test set(sol[1]) isa Hyperrectangle
-
-sol = solve(P, T=7.0, setrep=:IntervalBox, alg)
-@test set(sol[1]) isa IntervalBox
-
-sol = solve(P, T=7.0, setrep=:Zonotope, alg)
-@test set(sol[1]) isa Zonotope
-
-sol = solve(P, T=7.0, setrep=:TaylorModel, alg)
-@test set(sol[1]) isa TaylorModel
-=#
+    nothing  #hide  #md
+    return ivp, tspan  #jl
+end  #jl


### PR DESCRIPTION
This is a first proposal for adding the models to the documentation in Literate style.

One central issue is that the models are used in the tests and hence need functions to return the problem. But in the documentation such a function is causing problems when plotting. As a compromise I hide the `function model_name() [...] end` frame in the documentation, but the four leading spaces are still there.