### PR TITLE
Remove inner linear_map function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["mforets <mforets@gmail.com>", "schillic <christian.schilling@ist.ac.
 version = "0.9.1"
 
 [deps]
-ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 HybridSystems = "2207ec0c-686c-5054-b4d2-543502888820"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
@@ -30,7 +29,6 @@ CDDLib = "0.5, 0.6"
 DifferentialEquations = "6.11"
 Expokit = "0.2"
 ExponentialUtilities = "1.6, 1.7, 1.8"
-ExprTools = "0.1"
 HybridSystems = "0.3"
 IntervalArithmetic = "0.16, 0.17"
 IntervalMatrices = "0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["mforets <mforets@gmail.com>", "schillic <christian.schilling@ist.ac.
 version = "0.9.1"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 HybridSystems = "2207ec0c-686c-5054-b4d2-543502888820"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
@@ -29,6 +30,7 @@ CDDLib = "0.5, 0.6"
 DifferentialEquations = "6.11"
 Expokit = "0.2"
 ExponentialUtilities = "1.6, 1.7, 1.8"
+ExprTools = "0.1"
 HybridSystems = "0.3"
 IntervalArithmetic = "0.16, 0.17"
 IntervalMatrices = "0.6"

--- a/src/Algorithms/GLGM06/reach_homog.jl
+++ b/src/Algorithms/GLGM06/reach_homog.jl
@@ -23,7 +23,7 @@ function reach_homog_GLGM06!(F::Vector{ReachSet{N, Zonotope{N, VN, MN}}},
 
     k = 2
     @inbounds while k <= NSTEPS
-        Rₖ = _linear_map(Φ, set(F[k-1]))
+        Rₖ = linear_map(Φ, set(F[k-1]))
         Δt += δ
         F[k] = ReachSet(Rₖ, Δt)
         k += 1
@@ -67,7 +67,7 @@ function reach_homog_GLGM06!(F::Vector{ReachSet{N, Zonotope{N, Vector{N}, Matrix
 
     k = 2
     @inbounds while k <= NSTEPS
-        _linear_map!(Zout[k], Φ, Zout[k-1])
+        linear_map!(Zout[k], Φ, Zout[k-1])
         Δt += δ
         F[k] = ReachSet(Zout[k], Δt)
         k += 1
@@ -139,7 +139,7 @@ function reach_homog_GLGM06!(F::Vector{ReachSet{N, Zonotope{N, Vector{N}, Matrix
 
     k = 2
     while k <= NSTEPS
-        _linear_map!(Zout[k], Φ, Zout[k-1])
+        linear_map!(Zout[k], Φ, Zout[k-1])
         _is_intersection_empty(X, Zout[k], disjointness_method) && break
         Δt += δ
         F[k] = ReachSet(Zout[k], Δt)

--- a/src/Algorithms/GLGM06/reach_inhomog.jl
+++ b/src/Algorithms/GLGM06/reach_inhomog.jl
@@ -25,12 +25,12 @@ function reach_inhomog_GLGM06!(F::Vector{ReachSet{N, Zonotope{N, VN, MN}}},
 
     k = 2
     @inbounds while k <= NSTEPS
-        Rₖ = minkowski_sum(_linear_map(Φ_power_k, Ω0), Wk₊)
+        Rₖ = minkowski_sum(linear_map(Φ_power_k, Ω0), Wk₊)
         Rₖ = _reduce_order(Rₖ, max_order, reduction_method)
         Δt += δ
         F[k] = ReachSet(Rₖ, Δt)
 
-        Wk₊ = minkowski_sum(Wk₊, _linear_map(Φ_power_k, U))
+        Wk₊ = minkowski_sum(Wk₊, linear_map(Φ_power_k, U))
         Wk₊ = _reduce_order(Wk₊, max_order, reduction_method)
 
         mul!(Φ_power_k_cache, Φ_power_k, Φ)
@@ -63,13 +63,13 @@ function reach_inhomog_GLGM06!(F::Vector{ReachSet{N, Zonotope{N, VN, MN}}},
 
     k = 2
     @inbounds while k <= NSTEPS
-        Rₖ = minkowski_sum(_linear_map(Φ_power_k, Ω0), Wk₊)
+        Rₖ = minkowski_sum(linear_map(Φ_power_k, Ω0), Wk₊)
         Rₖ = _reduce_order(Rₖ, max_order, reduction_method)
         _is_intersection_empty(X, Rₖ, disjointness_method) && break
         Δt += δ
         F[k] = ReachSet(Rₖ, Δt)
 
-        Wk₊ = minkowski_sum(Wk₊, _linear_map(Φ_power_k, U))
+        Wk₊ = minkowski_sum(Wk₊, linear_map(Φ_power_k, U))
         Wk₊ = _reduce_order(Wk₊, max_order, reduction_method)
 
         mul!(Φ_power_k_cache, Φ_power_k, Φ)

--- a/src/Continuous/discretization.jl
+++ b/src/Continuous/discretization.jl
@@ -445,7 +445,7 @@ function discretize(ivp::IVP{<:CLCS, <:LazySet}, δ, alg::CorrectionHull)
         Y = _overapproximate(Φ * X0z, Zonotope)
     else
         Φ = _exp(A, δ, alg.exp)
-        Y = _linear_map(Φ, X0z)
+        Y = linear_map(Φ, X0z)
     end
 
     H = overapproximate(CH(X0z, Y), Zonotope)
@@ -474,7 +474,7 @@ function discretize(ivp::IVP{<:CLCCS, <:LazySet}, δ, alg::CorrectionHull)
         if isa(B, IntervalMatrix)
             Uz = _overapproximate(B * Uz, Zonotope)
         else
-            Uz = _linear_map(B, Uz)
+            Uz = linear_map(B, Uz)
         end
     else # LazySet
         Uz = _convert_or_overapproximate(Zonotope, U)
@@ -493,7 +493,7 @@ function discretize(ivp::IVP{<:CLCCS, <:LazySet}, δ, alg::CorrectionHull)
         Y = _overapproximate(Φ * X0z, Zonotope)
     else
         Φ = _exp(A, δ, alg.exp)
-        Y = _linear_map(Φ, X0z)
+        Y = linear_map(Φ, X0z)
     end
 
     H = overapproximate(CH(X0z, Y), Zonotope)

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -107,33 +107,6 @@ function Base.convert(::Type{Singleton},
 end
 
 # =========================
-# In-place ops
-# =========================
-
-# Extension of some common LazySets operations, some of them in-place
-
-# in-place scale of a zonotope
-# TODO update after LazySets#2274
-function scale!(α::Real, Z::Zonotope)
-    c = Z.center
-    G = Z.generators
-    c .= α .* c
-    G .= α .* G
-    return Z
-end
-
-# in-place linear map of a zonotope
-# TODO update after LazySets#2063
-@inline function _linear_map!(Zout::Zonotope, M::AbstractMatrix, Z::Zonotope)
-    mul!(Zout.center, M, Z.center)
-    mul!(Zout.generators, M, Z.generators)
-    return Zout
-end
-
-# TEMP
-@inline _linear_map(M, X) = LazySets.linear_map(M, X)
-
-# =========================
 # Projection
 # =========================
 

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -24,6 +24,9 @@ using LazySets: LinearMap, AffineMap, ResetMap
 # required to avoid conflicts with IntervalMatrices
 using LazySets: Interval, isdisjoint, radius, sample, ∅, dim
 
+# in-place set operations
+using LazySets: linear_map!
+
 # LazySets internal functions frequently used
 using LazySets.Arrays: projection_matrix, SingleEntryVector
 


### PR DESCRIPTION
The internal functions `_linear_map`, `_linear_map!` and `_scale!` are no longer needed because the patches are now available in LazySets. 