### PR TITLE
Macro for commutative binary functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["mforets <mforets@gmail.com>", "schillic <christian.schilling@ist.ac.
 version = "0.9.1"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 HybridSystems = "2207ec0c-686c-5054-b4d2-543502888820"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalMatrices = "5c1f47dc-42dd-5697-8aaa-4d102d140ba9"
@@ -29,6 +30,7 @@ CDDLib = "0.5, 0.6"
 DifferentialEquations = "6.11"
 Expokit = "0.2"
 ExponentialUtilities = "1.6, 1.7, 1.8"
+ExprTools = "0.1"
 HybridSystems = "0.3"
 IntervalArithmetic = "0.16, 0.17"
 IntervalMatrices = "0.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,8 +63,9 @@ makedocs(
                                "Discretization" => "lib/discretize.md",
                                "Projections" => "lib/projections.md",
                                "Clustering" => "lib/clustering.md",
-                               "Further operations" => "lib/operations.md",
-                               "Distributed computations" => "lib/distributed.md"],
+                               "Further set operations" => "lib/operations.md",
+                               "Distributed computations" => "lib/distributed.md",
+                               "Internal functions and macros" => "lib/internals.md"],
         "References" => "references.md",
         "About" => "about.md"
     ]

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -1,0 +1,19 @@
+```@meta
+DocTestSetup = :(using ReachabilityAnalysis)
+CurrentModule = ReachabilityAnalysis
+```
+
+# Internal functions and macros
+
+This section of the manual includes some internal (i.e. unexported) functions and
+macros used within the library.
+
+```@contents
+Pages = ["internals.md"]
+Depth = 3
+```
+
+```@docs
+@requires
+@commutative
+```

--- a/docs/src/lib/operations.md
+++ b/docs/src/lib/operations.md
@@ -3,7 +3,7 @@ DocTestSetup = :(using ReachabilityAnalysis)
 CurrentModule = ReachabilityAnalysis
 ```
 
-# Further operations
+# Further set operations
 
 ## Convexification
 

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -7,8 +7,8 @@ using LinearAlgebra, SparseArrays, # modules from the Julia standard library
       RecipesBase,                 # plotting
       Parameters,                  # structs with kwargs
       StaticArrays,                # statically sized arrays
-      RecursiveArrayTools          # vector of arrays
-      #ExponentialUtilities        # (optional) Krylov subspace approximations
+      RecursiveArrayTools,         # vector of arrays type
+      ExprTools                    # manipulate function definition expressions
 
 # the reexport macro ensures that the names exported by the following libraries
 # are made available after loading ReachabilityAnalysis
@@ -80,20 +80,82 @@ const symI = IA.Interval(-1.0, 1.0)
 
 using Requires
 
-# convenience macro to annotate that a package is required
-# usage:
-# function foo(...)
-#   @require MyPackage
-#   ... # functionality that requires MyPackage to be loaded
-# end
+function __init__()
+    # numerical differential equations suite
+    @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" include("init_DifferentialEquations.jl")
+
+    # exponentiation methods using Krylov subspace approximations
+    @require ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18" include("init_ExponentialUtilities.jl")
+
+    # tools for symbolic computation
+    @require ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78" include("init_ModelingToolkit.jl")
+end
+
+# ===========================
+# Utility macros
+# ===========================
+
+"""
+    @requires(module_name)
+
+Convenience macro to annotate that a package is required to use a certain function.
+
+### Input
+
+- `module_name` -- name of the required package
+
+### Output
+
+The macro expands to an assertion that checks whether the module `module_name` is
+known in the calling scope.
+
+### Notes
+
+Usage:
+
+```julia
+function foo(...)
+    @require MyPackage
+    ... # functionality that requires MyPackage to be loaded
+end
+```
+"""
 macro requires(module_name)
     m = Meta.quot(Symbol(module_name))
     return esc(:(@assert isdefined(@__MODULE__, $m) "package `$($m)` is required " *
                     "for this function; do `using $($m)` and try again"))
 end
 
-function __init__()
-    @require DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa" include("init_DifferentialEquations.jl")
-    @require ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18" include("init_ExponentialUtilities.jl")
-    @require ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78" include("init_ModelingToolkit.jl")
+"""
+    @commutative(FUN)
+
+Macro to declare that a given function `FUN` is commutative, returning the original
+`FUN` and a new method of `FUN` where the first and second arguments are swapped.
+
+### Input
+
+- `FUN` -- function name
+
+### Output
+
+A quoted expression containing the function definitions.
+"""
+macro commutative(FUN)
+    # split the function definition expression
+    def = splitdef(FUN)
+    FUNARGS = copy(def[:args])
+
+    # swap arguments 1 and 2
+    aux = def[:args][1]
+    def[:args][1] = def[:args][2]
+    def[:args][2] = aux
+
+    # the new function calls f with swapped arguments
+    def[:body] = quote ($(def[:name]))($(FUNARGS...)) end
+
+    _FUN = combinedef(def)
+    return quote
+        $(esc(FUN))
+        $(esc(_FUN))
+     end
 end


### PR DESCRIPTION
This macro is useful to annotate functions that are commutative with respect to its first two arguments, automatically creating `foo(Y, X)` given `foo(X, Y)`. 

(This method is from LazySets PR https://github.com/JuliaReach/LazySets.jl/pull/2286 but it is not available in that package yet.)