### PR TITLE
Update ensemble solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 CDDLib = "0.5, 0.6"
-DifferentialEquations = "6.11"
+DifferentialEquations = "6.16"
 Expokit = "0.2"
 ExponentialUtilities = "1.6, 1.7, 1.8"
 ExprTools = "0.1"

--- a/src/Continuous/normalization.jl
+++ b/src/Continuous/normalization.jl
@@ -9,28 +9,6 @@
 import Base: *
 import LazySets.constrained_dimensions
 
-# common aliases for system's names
-const LCS = LinearContinuousSystem
-const LDS = LinearDiscreteSystem
-const CLCS = ConstrainedLinearContinuousSystem
-const CLDS = ConstrainedLinearDiscreteSystem
-const CLCCS = ConstrainedLinearControlContinuousSystem
-const CLCDS = ConstrainedLinearControlDiscreteSystem
-const ACS = AffineContinuousSystem
-const ADS = AffineDiscreteSystem
-const CACCS = ConstrainedAffineControlContinuousSystem
-const CACDS = ConstrainedAffineControlDiscreteSystem
-const CACS = ConstrainedAffineContinuousSystem
-const CADS = ConstrainedAffineDiscreteSystem
-const BBCS = BlackBoxContinuousSystem
-const CBBCS = ConstrainedBlackBoxContinuousSystem
-const CBBCCS = ConstrainedBlackBoxControlContinuousSystem
-const SOLCS = SecondOrderLinearContinuousSystem
-const SOACS = SecondOrderAffineContinuousSystem
-const SOCLCCS = SecondOrderConstrainedLinearControlContinuousSystem
-const SOCACCS = SecondOrderConstrainedAffineControlContinuousSystem
-const SecondOrderSystem = Union{SOLCS, SOACS, SOCLCCS, SOCACCS}
-
 # continuous systems that are handled by this library
 iscontinuoussystem(T::Type{<:AbstractSystem}) = false
 iscontinuoussystem(T::Type{<:LCS}) = true

--- a/src/Continuous/solve.jl
+++ b/src/Continuous/solve.jl
@@ -60,12 +60,12 @@ function solve(ivp::IVP{<:AbstractContinuousSystem}, args...; kwargs...)
     # run the continuous-post operator
     F = post(cpost, ivp, tspan; kwargs...)
 
-    if haskey(kwargs, :save_traces) && kwargs[:save_traces]
+    if haskey(kwargs, :ensemble) && kwargs[:ensemble]
         @requires DifferentialEquations
-        error("saving traces is not implemented yet")
-        # compute trajectories, cf. ensemble simulation
-        # traces = ...
-        # sol = ReachSolution(F, cpost, traces) # new solution type?
+        # compute trajectories using ensemble simulation
+        ensemble_sol = _solve_ensemble(ivp, args...; kwargs...)
+        dict = Dict{Symbol,Any}(:ensemble=>ensemble_sol)
+        sol = ReachSolution(F, cpost, dict)
     else
         # wrap the flowpipe and algorithm in a solution structure
         sol = ReachSolution(F, cpost)

--- a/src/Flowpipes/fields.jl
+++ b/src/Flowpipes/fields.jl
@@ -1,8 +1,6 @@
-# See MathematicalSystems#160
-MathematicalSystems.system(sys::AbstractSystem) = sys
-#MathematicalSystems.system(sys::InitialValueProblem) = sys.s
+abstract type AbstractVectorField end
 
-struct VectorField{T}
+struct VectorField{T} <: AbstractVectorField
     field::T
 end
 
@@ -15,7 +13,9 @@ function evaluate(V::VectorField, args...)
     return V.field(args...)
 end
 
-function VectorField(sys::AbstractSystem)
+VectorField(sys::InitialValueProblem) = VectorField(system(sys))
+
+function VectorField(sys::AbstractContinuousSystem)
     sys = system(sys)
     if islinear(sys)
         if inputdim(sys) == 0

--- a/src/Flowpipes/fields.jl
+++ b/src/Flowpipes/fields.jl
@@ -68,3 +68,9 @@ function inplace_field!(ivp::InitialValueProblem)
          end
     return f!
 end
+
+# for "black-box" MathematicalSystems, return the function field directly
+
+function inplace_field!(ivp::IVP{<:NonlinearSystem})
+    return ivp.s.f # TODO getter?
+end

--- a/src/Flowpipes/solutions.jl
+++ b/src/Flowpipes/solutions.jl
@@ -54,6 +54,7 @@ sets, and a dictionary of options.
 ### Fields
 
 - `Xk`       -- the list of [`AbstractReachSet`](@ref)s
+- `alg`      -- algorihm used
 - `options`  -- the dictionary of options
 """
 struct ReachSolution{FT<:AbstractFlowpipe, ST<:AbstractPost} <: AbstractSolution
@@ -75,6 +76,7 @@ tspan(sol::ReachSolution) = tspan(sol.F)
 tstart(sol::ReachSolution, arr::AbstractVector) = tstart(sol.F, arr)
 tend(sol::ReachSolution, arr::AbstractVector) = tend(sol.F, arr)
 tspan(sol::ReachSolution, arr::AbstractVector) = tspan(sol.F, arr)
+ensemble(sol::ReachSolution) = get(sol.ext, :ensemble, nothing)
 
 # NOTE: using sol.alg for setrep and rsetrep may be inaccurate as solutions
 # do not change their sol.alg (eg. overapproximate(sol, Zonotope)) where sol is

--- a/src/Initialization/exports.jl
+++ b/src/Initialization/exports.jl
@@ -4,6 +4,7 @@ export
     normalize,
     discretize,
     homogeneize,
+    ensemble,
 
 # Algorithms
     A20,

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -74,6 +74,29 @@ const zeroI = IA.Interval(0.0) # TODO use number type
 const oneI = IA.Interval(1.0)
 const symI = IA.Interval(-1.0, 1.0)
 
+# common aliases for system's names
+const LCS = LinearContinuousSystem
+const LDS = LinearDiscreteSystem
+const CLCS = ConstrainedLinearContinuousSystem
+const CLDS = ConstrainedLinearDiscreteSystem
+const CLCCS = ConstrainedLinearControlContinuousSystem
+const CLCDS = ConstrainedLinearControlDiscreteSystem
+const ACS = AffineContinuousSystem
+const ADS = AffineDiscreteSystem
+const CACCS = ConstrainedAffineControlContinuousSystem
+const CACDS = ConstrainedAffineControlDiscreteSystem
+const CACS = ConstrainedAffineContinuousSystem
+const CADS = ConstrainedAffineDiscreteSystem
+const BBCS = BlackBoxContinuousSystem
+const CBBCS = ConstrainedBlackBoxContinuousSystem
+const CBBCCS = ConstrainedBlackBoxControlContinuousSystem
+const SOLCS = SecondOrderLinearContinuousSystem
+const SOACS = SecondOrderAffineContinuousSystem
+const SOCLCCS = SecondOrderConstrainedLinearControlContinuousSystem
+const SOCACCS = SecondOrderConstrainedAffineControlContinuousSystem
+const SecondOrderSystem = Union{SOLCS, SOACS, SOCLCCS, SOCACCS}
+const NonlinearSystem = Union{BBCS, CBBCS, CBBCCS}
+
 # ======================
 # Optional dependencies
 # ======================

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -82,7 +82,7 @@ using Requires
 
 function __init__()
     # numerical differential equations suite
-    @require OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed" include("init_DifferentialEquations.jl")
+    @require DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa" include("init_DifferentialEquations.jl")
 
     # exponentiation methods using Krylov subspace approximations
     @require ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18" include("init_ExponentialUtilities.jl")

--- a/src/Initialization/init_DifferentialEquations.jl
+++ b/src/Initialization/init_DifferentialEquations.jl
@@ -28,7 +28,7 @@ function _solve_ensemble(ivp::InitialValueProblem, args...;
     X0_samples = sample(X0, trajectories)
 
     # formulate ensemble ODE problem
-    ensemble_prob = ODEProblem(field, first(X0), tspan)
+    ensemble_prob = ODEProblem(field, first(X0_samples), tspan)
     _prob_func(prob, i, repeat) = remake(prob, u0 = X0_samples[i])
 
     ensemble_prob = EnsembleProblem(ensemble_prob, prob_func = _prob_func)

--- a/src/Initialization/init_DifferentialEquations.jl
+++ b/src/Initialization/init_DifferentialEquations.jl
@@ -1,15 +1,36 @@
-using .OrdinaryDiffEq
+using .DifferentialEquations
+const DE = DifferentialEquations
+
+LazySets.sample(X::IntervalArithmetic.Interval, d::Integer) = sample(convert(Interval, X), d)
+LazySets.sample(X::IntervalArithmetic.IntervalBox, d::Integer) = sample(convert(Hyperrectangle, X), d)
 
 # extend the solve API for initial-value problems
-function OrdinaryDiffEq.solve(ivp::InitialValueProblem, args...; kwargs...)
-    tspan = _get_tspan(args...; kwargs...)
-    tspan = (inf(tspan), sup(tspan))
-    inplace = haskey(kwargs, :inplace) ? kwargs[:inplace] : true
+function _solve_ensemble(ivp::InitialValueProblem, args...;
+                         trajectories=100,
+                         trajectories_alg=DE.Tsit5(),
+                         ensemble_alg=DE.EnsembleDistributed(),
+                         inplace=true,
+                         kwargs...)
+
+    # get problem's vector field
     if inplace
         field = inplace_field!(ivp)
     else
         field = outofplace_field(ivp)
     end
-    odeprob = ODEProblem(field, initial_state(ivp), tspan)
-    return OrdinaryDiffEq.solve(odeprob, args...; kwargs...)
+
+    # get time span
+    dt = _get_tspan(args...; kwargs...)
+    tspan = (inf(dt), sup(dt))
+
+    # sample initial states
+    X0 = initial_state(ivp)
+    X0_samples = sample(X0, trajectories)
+
+    # formulate ensemble ODE problem
+    ensemble_prob = ODEProblem(field, first(X0), tspan)
+    _prob_func(prob, i, repeat) = remake(prob, u0 = X0_samples[i])
+
+    ensemble_prob = EnsembleProblem(ensemble_prob, prob_func = _prob_func)
+    return DE.solve(ensemble_prob, trajectories_alg, ensemble_alg; trajectories = trajectories)
 end

--- a/src/Initialization/init_DifferentialEquations.jl
+++ b/src/Initialization/init_DifferentialEquations.jl
@@ -1,7 +1,7 @@
-using .DifferentialEquations
+using .OrdinaryDiffEq
 
 # extend the solve API for initial-value problems
-function DifferentialEquations.solve(ivp::InitialValueProblem, args...; kwargs...)
+function OrdinaryDiffEq.solve(ivp::InitialValueProblem, args...; kwargs...)
     tspan = _get_tspan(args...; kwargs...)
     tspan = (inf(tspan), sup(tspan))
     inplace = haskey(kwargs, :inplace) ? kwargs[:inplace] : true
@@ -11,5 +11,5 @@ function DifferentialEquations.solve(ivp::InitialValueProblem, args...; kwargs..
         field = outofplace_field(ivp)
     end
     odeprob = ODEProblem(field, initial_state(ivp), tspan)
-    return DifferentialEquations.solve(odeprob, args...; kwargs...)
+    return OrdinaryDiffEq.solve(odeprob, args...; kwargs...)
 end


### PR DESCRIPTION
```julia
@time using ReachabilityAnalysis, DifferentialEquations
using Plots

using ReachabilityAnalysis: solve

┌ Info: Precompiling ReachabilityAnalysis [1e97bd63-91d1-579d-8e8d-501d2b57c93f]
└ @ Base loading.jl:1278
 50.864150 seconds (86.59 M allocations: 4.762 GiB, 2.69% gc time)
WARNING: using DifferentialEquations.solve in module ReachabilityAnalysis conflicts with an existing identifier.

prob = @ivp(x' = 1.01x, x(0) ∈ 0 .. 0.5);

@time sol = solve(prob, tspan=(0.0, 1.0));

@time sol = solve(prob, tspan=(0.0, 1.0), ensemble=false);
@time sol = solve(prob, tspan=(0.0, 1.0), ensemble=true);

  0.000028 seconds (627 allocations: 14.516 KiB)
  0.000045 seconds (627 allocations: 14.516 KiB)
  0.002557 seconds (12.66 k allocations: 1.287 MiB)

plot(sol, vars=(0, 1))
plot!(ensemble(sol), vars=(0, 1))
```

![Screenshot from 2020-12-28 16-35-21](https://user-images.githubusercontent.com/12424594/103238912-e2f39380-492a-11eb-9715-550c3995a73a.png)
