### PR TITLE
update concrete complement

### DIFF
--- a/src/Flowpipes/reachsets.jl
+++ b/src/Flowpipes/reachsets.jl
@@ -271,7 +271,7 @@ LazySets.area(R::AbstractLazyReachSet) = area(set(R))
 LazySets.volume(R::AbstractLazyReachSet) = volume(set(R))
 Base.convert(::Type{ST}, R::AbstractLazyReachSet) where {ST<:LazySet} = convert(ST, set(R))
 Base.convert(::Type{<:IntervalBox}, R::AbstractLazyReachSet) = convert(IntervalBox, set(R))
-complement(R::AbstractLazyReachSet) = reconstruct(R, complement(set(R)))
+LazySets.complement(R::AbstractLazyReachSet) = reconstruct(R, complement(set(R)))
 
 # forward to internal function _is_intersection_empty, which admit a pre-processing
 # step for the reach-set / algorithm choice

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -399,21 +399,6 @@ function LazySets.Approximations.box_approximation(x::IntervalArithmetic.Interva
     return convert(Hyperrectangle, x)
 end
 
-# concrete set complement for polyhedral sets
-# see LazySets#2381
-complement(X::LazySet) = UnionSetArray(constraints_list(Complement(X)))
-
-# list of constraints of the set complement of a polyhedral set
-# see LazySets#2381
-function LazySets.constraints_list(CX::Complement{N, ST}) where {N, ST<:AbstractPolyhedron{N}}
-    clist = constraints_list(CX.X)
-    out = similar(clist)
-    for (i, ci) in enumerate(clist)
-        out[i] = LinearConstraint(-ci.a, -ci.b)
-    end
-    return out
-end
-
 LazySets.box_approximation(S::UnionSetArray) = overapproximate(S, Hyperrectangle)
 
 function LazySets.overapproximate(S::UnionSetArray{N}, ::Type{<:Hyperrectangle}) where {N}


### PR DESCRIPTION
Now available in LazySets (https://github.com/JuliaReach/LazySets.jl/pull/2469) we can remove the patch.