### PR TITLE
Extend projection recipe for template reach-sets

### DIFF
--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -24,7 +24,7 @@ MODELS = ["Brusselator/Brusselator.jl",
           #"LotkaVolterraTangential/LotkaVolterraTangential.jl",
           "OpAmp/OpAmp.jl",
           #"SquareWaveOscillator/SquareWaveOscillator.jl", # FIXME review plotting workflow
-          #"Platoon/Platoon.jl", # FIXME review plotting workflow
+          "Platoon/Platoon.jl",
           "ProductionDestruction/ProductionDestruction.jl",
           "Quadrotor/Quadrotor.jl",
           "SEIR/SEIR.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,7 +41,7 @@ makedocs(
                           "Brusselator" => "models/Brusselator.md",
                           "Structural Model" => "models/ISS.md",
                           "Lorenz system" => "models/Lorenz.md",
-                          #"Platoon" => "models/Platoon.md",
+                          "Platoon" => "models/Platoon.md",
                           "Quadrotor" => "models/Quadrotor.md",
                           "SEIR model" => "models/SEIR.md",
                           "Spacecraft" => "models/Spacecraft.md"],

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -4,7 +4,7 @@ This page includes references to the scientific works that we have applied
 throughout this library. Although the list is not meant to be exhaustive, we think
 it should give a solid starting place for those who want to explore further.
 
-If you use `ReachabilityAnalysis.jl` for your own work, please consider citing the
+If you use [ReachabilityAnalysis.jl](https://github.com/JuliaReach/ReachabilityAnalysis.jl) for your own work, please consider citing the
 appropriate original reference(s). For this purpose we provide the BibTeX citation
 in each case.
 

--- a/test/models/ISS.jl
+++ b/test/models/ISS.jl
@@ -18,18 +18,6 @@ function ISSF01()
     return @ivp(x' = A*x + B*u, x(0) ∈ X0, u ∈ U, x ∈ Universe(270))
 end
 
-function ISSC01()
-    @load ISS_path A B
-
-    A_ext = add_dimension(A, 3)
-    A_ext[1:270, 271:273] = B
-
-    U = Hyperrectangle(low=[0.0, 0.8, 0.9], high=[0.1, 1., 1.])
-    X0 = BallInf(zeros(size(A, 1)), 0.0001)
-    X0 = X0 * U
-    return @ivp(x' = A_ext*x, x(0) ∈ X0)
-end
-
 dirs = CustomDirections([C3, -C3]);
 prob_ISSF01 = ISSF01();
 sol_ISSF01 = solve(prob_ISSF01, T=20.0, alg=LGG09(δ=6e-4, template=dirs, sparse=true, cache=false));
@@ -52,6 +40,18 @@ Plots.plot!(fig, πsol_ISSF01[1:10:end], vars=(0, 1), linecolor=:blue, color=:bl
      bottom_margin=6mm, left_margin=2mm, right_margin=4mm, top_margin=3mm);
 fig
 
+function ISSC01()
+    @load ISS_path A B
+
+    A_ext = add_dimension(A, 3)
+    A_ext[1:270, 271:273] = B
+
+    U = Hyperrectangle(low=[0.0, 0.8, 0.9], high=[0.1, 1., 1.])
+    X0 = BallInf(zeros(size(A, 1)), 0.0001)
+    X0 = X0 * U
+    return @ivp(x' = A_ext*x, x(0) ∈ X0)
+end
+
 dirs = CustomDirections([C3_ext, -C3_ext]);
 prob_ISSC01 = ISSC01();
 sol_ISSC01 = solve(prob_ISSC01, T=20.0, alg=LGG09(δ=0.01, template=dirs, sparse=true, cache=false));
@@ -60,11 +60,10 @@ sol_ISSC01 = solve(prob_ISSC01, T=20.0, alg=LGG09(δ=0.01, template=dirs, sparse
 
 fig = Plots.plot();
 Plots.plot!(fig, πsol_ISSC01, vars=(0, 1), linecolor=:blue, color=:blue, alpha=0.8, lw=1.0,
-   #tickfont=font(30, "Times"), guidefontsize=45, !jl
     xlab=L"t",
     ylab=L"y_{3}",
     xtick=[0, 5, 10, 15, 20.], ytick=[-0.0002, -0.0001, 0.0, 0.0001, 0.0002],
     xlims=(0., 20.), ylims=(-0.0002, 0.0002),
-    bottom_margin=6mm, left_margin=2mm, right_margin=4mm, top_margin=3mm);
+    bottom_margin=6mm, left_margin=2mm, right_margin=4mm, top_margin=3mm)
 fig
 

--- a/test/models/Platoon.jl
+++ b/test/models/Platoon.jl
@@ -1,4 +1,4 @@
-using ReachabilityAnalysis, SparseArrays, ModelingToolkit
+using ReachabilityAnalysis, SparseArrays, Symbolics
 
 const var = @variables x[1:9] t
 


### PR DESCRIPTION
This PR extends the logic in `_project_reachset(R::TemplateReachSet, vars)` such that the "fast" and exact AbstractPolyhedron projection method from LazySets is used if it is applicable, otherwise we overapproximate the lazy projection.