### PR TITLE
Changes to skip first set

### DIFF
--- a/src/Algorithms/TMJets/TMJets21a/post.jl
+++ b/src/Algorithms/TMJets/TMJets21a/post.jl
@@ -42,10 +42,13 @@ function post(alg::TMJets21a{N}, ivp::IVP{<:AbstractContinuousSystem}, timespan;
                                                  absorb=absorb,
                                                  check_property=check_property)
 
-    # build flowpipe
+    # preallocate flowpipe
     F = Vector{TaylorModelReachSet{N}}()
     sizehint!(F, maxsteps)
-    @inbounds for i in eachindex(tv)
+
+    # loop over reach-sets (the first reach-set at the initial time point is ignored)
+    @inbounds for i in 2:length(tv)
+
         # create Taylor model reach-set
         δt = TimeInterval(tv[i] + domain(xTM1v[1, i]))
         Ri = TaylorModelReachSet(xTM1v[:, i], δt + Δt0)

--- a/src/Algorithms/TMJets/TMJets21b/post.jl
+++ b/src/Algorithms/TMJets/TMJets21b/post.jl
@@ -46,7 +46,10 @@ function post(alg::TMJets21b{N}, ivp::IVP{<:AbstractContinuousSystem}, timespan;
     # build flowpipe
     F = Vector{TaylorModelReachSet{N}}()
     sizehint!(F, maxsteps)
-    for i in eachindex(tv)
+
+    # loop over reach-sets (the first reach-set at the initial time point is ignored)
+    @inbounds for i in 2:length(tv)
+
         # create Taylor model reach-set
         δt = TimeInterval(tv[i] + domain(xTM1v[1, i]))
         Ri = TaylorModelReachSet(xTM1v[:, i], δt + Δt0)

--- a/src/Algorithms/TMJets/common.jl
+++ b/src/Algorithms/TMJets/common.jl
@@ -29,7 +29,10 @@ function _initialize(X0::LazySet, orderQ, orderT)
 end
 
 # taylor model representations
-_initialize(X0::TaylorModelReachSet, orderQ, orderT) = set(X0)
+function _initialize(X0::TaylorModelReachSet, orderQ, orderT)
+    return set(X0)
+end
+
 _initialize(X0::Vector{TaylorModel1{TaylorN{T}, T}}, orderQ, orderT) where {T} = X0
 
 # hyperrectangular sets


### PR DESCRIPTION
This restores the usual behavior (do not return the set of initial states, only the propagated states).