### PR TITLE
Remove redundant generators when plotting zonotopes

### DIFF
--- a/src/Flowpipes/recipes.jl
+++ b/src/Flowpipes/recipes.jl
@@ -34,6 +34,10 @@ function _project_reachset(R::AbstractLazyReachSet, vars)
         # concrete projection is efficient
         πR = project(R, vars)
         X = set(πR)
+        if ST <: AbstractZonotope
+            # zonotopes usually contain lots of redundant generators
+            X = remove_redundant_generators(X)
+        end
 
     elseif (ST <: AbstractPolyhedron) && (dim(R) == 2)
         # if the set is polyhedral and two-dimensional


### PR DESCRIPTION
x-ref: #453

Here are the numbers of generators before and after removing when plotting a flowpipe for some model (`Airplane`). This is an 18-dimensional model, so removing generators helps a lot.
```
25
3
25
3
25
3
25
3
25
3
25
3
25
3
25
2
25
2
25
2
25
2
25
2
31
3
31
3
31
3
31
4
31
4
31
3
31
3
31
2
31
2
31
2
31
2
31
2
31
2
31
2
```