### PR TITLE
Add discretization method from d/dt

### DIFF
--- a/src/Discretization/ForwardDdt.jl
+++ b/src/Discretization/ForwardDdt.jl
@@ -1,0 +1,109 @@
+# ==================================
+# Forward approximation from d/dt
+# ==================================
+
+"""
+    ForwardDdt{EM, SO, SI, IT, BT} <: AbstractApproximationModel
+
+Forward approximation model used in `d/dt`. It can be used for overapproximation
+and underapproximation.
+
+### Fields
+
+- `oa`      -- (optional, default: `true`) flag to choose between
+               overapproximation and underapproximation
+- `exp`     -- (optional, default: `BaseExp`) exponentiation method
+- `setops`  -- (optional, default: `:lazy`) set operations method
+- `sih`     -- (optional, default: `:concrete`) way to compute the symmetric
+               interval hull
+- `inv`     -- (optional, default: `false`) if `true`, assume that the state
+               matrix is invertible and use its inverse in the `Φ` functions
+- `backend` -- (optional, default: `nothing`) used if the algorithm needs to
+               apply concrete polyhedral computations
+
+### Algorithm
+
+The transformations are:
+
+- ``Φ ← \\exp(Aδ)``,
+- ``Ω_0 ← bloat(CH(\\mathcal{X}_0, Φ\\mathcal{X}_0), ε)``
+
+where ``bloat(\\mathcal{X}, ε)`` bloats the set ``\\mathcal{X}`` with the value
+``ε``. If `oa == false`, the bloating acts in an inverted way and shrinks the
+set.
+
+### Reference
+
+E. Asarin, T. Dang, O. Maler, O. Bournez: *Approximate reachability analysis of
+piecewise-linear dynamical systems*. HSCC 2000.
+"""
+struct ForwardDdt{EM, SO, SI, IT, BT} <: AbstractApproximationModel
+    oa::Bool
+    exp::EM
+    setops::SO
+    sih::SI
+    inv::IT
+    backend::BT
+end
+
+hasbackend(alg::ForwardDdt) = !isnothing(alg.backend)
+
+# convenience constructor using symbols
+function ForwardDdt(; oa::Bool=true, exp=BaseExp, setops=:lazy, sih=:concrete,
+                      inv=false, backend=nothing)
+    return ForwardDdt(oa, _alias(exp), _alias(setops), Val(sih), Val(inv), backend)
+end
+
+function Base.show(io::IO, alg::ForwardDdt)
+    print(io, "`ForwardDdt` approximation model with: \n")
+    print(io, "    - $(alg.oa ? "over" : "under")approximation \n")
+    print(io, "    - exponentiation method: $(alg.exp) \n")
+    print(io, "    - set operations method: $(alg.setops)\n")
+    print(io, "    - symmetric interval hull method: $(alg.sih)\n")
+    print(io, "    - invertibility assumption: $(alg.inv)")
+    print(io, "    - polyhedral computations backend: $(alg.backend)")
+end
+
+Base.show(io::IO, m::MIME"text/plain", alg::ForwardDdt) = print(io, alg)
+
+# ------------------------------------------------------------
+# ForwardDdt Approximation: Homogeneous case
+# ------------------------------------------------------------
+
+# if A == |A|, then Φ can be reused in the computation of Φ₂(|A|, δ)
+function discretize(ivp::IVP{<:CLCS, <:LazySet}, δ, alg::ForwardDdt)
+    A = state_matrix(ivp)
+    X0 = initial_state(ivp)
+
+    Φ = _exp(A, δ, alg.exp)
+    Y = ConvexHull(X0, Φ * X0)
+    Y = _apply_setops(Y, alg)
+
+    # bloating
+    ε = _estimate_bloating_value_ddt(A, X0, δ)
+    if !alg.oa
+        ε = -ε
+    end
+    Ω0 = Bloating(Y, ε)
+
+    X = stateset(ivp)
+    Sdis = ConstrainedLinearDiscreteSystem(Φ, X)
+    return InitialValueProblem(Sdis, Ω0)
+end
+
+function _estimate_bloating_value_ddt(A, X0, δ)
+    norm_A = opnorm(A)
+    u = 1/8 * norm_A^2 * δ^2
+    v = exp(norm_A * δ) - 1 - (norm_A * δ) - (norm_A^2 * δ^2 / 2)
+    return (u + v) * norm(X0)
+end
+
+# outer bloating a polytope into a polytope
+function _bloat(P::LazySet, ε)
+    A, b = tosimplehrep(P)
+    bε = copy(b)
+    for i in 1:length(b)
+        bε[i] += ε * opnorm(transpose(A[i, :]))
+    end
+    return HPolytope(A, bε)
+end

--- a/src/Discretization/discretization.jl
+++ b/src/Discretization/discretization.jl
@@ -101,11 +101,14 @@ include("CorrectionHull.jl")
 # Intersect one step forward in time with one step backward
 include("StepIntersect.jl")
 
+# Forward approximation from d/dt
+include("ForwardDdt.jl")
+
 # =========================================================================
 # Alternatives to apply the set operation depending on the desired output
 # =========================================================================
 
-function _apply_setops(X, alg::Forward)
+function _apply_setops(X, alg::AbstractApproximationModel)
     if hasbackend(alg)
         _apply_setops(X, alg.setops, alg.backend)
     else

--- a/test/algorithms/LGG09.jl
+++ b/test/algorithms/LGG09.jl
@@ -50,3 +50,22 @@ end
     @test setrep(sol) == HPolyhedron{Float64, Vector{Float64}}
     @test dim(sol) == 5
 end
+
+@testset "LGG09 algorithm: underapproximation" begin
+    X0 = BallInf([1.0, 1.0], 0.1)
+    function foo()
+        A = [0.0 1.0; -1.0 0.0]
+        prob = @ivp(x' = Ax, x(0) ∈ X0)
+        tspan = (0.0, 20.0)
+        return prob, tspan
+    end
+    prob, dt = foo()
+    δ = 2e-1
+
+    approx_model = ReachabilityAnalysis.ForwardDdt()
+    sol = solve(prob, tspan=(0.0, 20.0),
+                alg=LGG09(δ=δ, template=PolarDirections(40), approx_model=approx_model))
+    approx_model = ReachabilityAnalysis.ForwardDdt(oa=false)
+    sol_ua = solve(prob, tspan=(0.0, 20.0),
+                   alg=LGG09(δ=δ, template=PolarDirections(40), approx_model=approx_model))
+end


### PR DESCRIPTION
~This requires https://github.com/JuliaReach/LazySets.jl/pull/2800.~

```julia
using ReachabilityAnalysis, Plots
using ReachabilityAnalysis: ForwardDdt
import DifferentialEquations

A = [0.0 1.0; -1.0 0.0]
X0 = BallInf([1.0, 1.0], 0.1)

prob = @ivp(x' = Ax, x(0) ∈ X0)
dt = (0.0, 20.0)

δ = 2e-1
X1 = linear_map(exp(A*δ), X0)
template = PolarDirections(200)

sol = solve(prob, ensemble=true, include_vertices=true, trajectories=0, tspan=dt, alg=LGG09(δ=δ, template=template, approx_model=ForwardDdt()));
sol_ua = solve(prob, tspan=dt, alg=LGG09(δ=δ, template=template, approx_model=ForwardDdt(oa=false)));

plot(X0)
plot!(X1)
plot!(sol[1], vars=(1, 2), alpha=0.2)
plot!(convex_hull(X0, X1), alpha=0.2)
plot!(sol_ua[1], vars=(1, 2), alpha=0.5)
plot!(ensemble(sol), vars=(1, 2), alpha=1, c=:black)
xlims!(-ρ([-1.0, 0.0], sol[1]), ρ([1.0, 0.0], sol[1]))
ylims!(-ρ([0.0, -1.0], sol[1]), ρ([0.0, 1.0], sol[1]))
```

![ua1](https://user-images.githubusercontent.com/9656686/127738541-a801bbf0-fd4e-4927-a14a-11ff98486328.png)

```julia

plot(sol[1:9], vars=(1, 2), alpha=0.2)
plot!(sol_ua[1:9], vars=(1, 2), alpha=0.5)
plot!(ensemble(sol), vars=(1, 2), alpha=1, c=:black)
xlims!(1, 1.6)
```

![ua2](https://user-images.githubusercontent.com/9656686/127738545-f4331326-59eb-4f7d-83ad-7c6f14f70ffa.png)
