### PR TITLE
Fix docs problem

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,7 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
@@ -12,5 +13,4 @@ PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-Documenter = "0.25"
 JLD2 = "0.4"

--- a/docs/src/tutorials/set_representations/zonotopes.md
+++ b/docs/src/tutorials/set_representations/zonotopes.md
@@ -12,6 +12,7 @@ an affine transformation. For example,
 
 ```@example zonotope_definition
 using LazySets, Plots #hide
+using LazySets: center #hide
 
 B = BallInf(zeros(2), 1.0) # unit cube
 M = [0 1; -1 0] # an affine transformation
@@ -37,7 +38,7 @@ $Z = (c, G)$, where $g_i$ is the $i$-th column of $G$. In the examle of above,
 
 The generators can be
 
-```@example
+```@example zonotope_definition
 Z3 = Zonotope([1.0, 0.0], [0.1 0.0; 0.0 0.1])
 ```
 
@@ -47,8 +48,7 @@ of a given zonotope.
 
 
 
-```@example zonotope_example_1
-
+```@example zonotope_definition
 Z = Zonotope([1, 1.], [-1 0.3 1.5 0.3; 0 0.1 -0.3 0.3])
 plot(Z)
 quiver!(fill(1., 4), fill(1., 4), quiver=(genmat(Z)[1, :], genmat(Z)[2, :]), color=:black)

--- a/test/models/LotkaVolterra.jl
+++ b/test/models/LotkaVolterra.jl
@@ -1,4 +1,4 @@
-using ReachabilityAnalysis, JLD2
+using ReachabilityAnalysis
 
 @taylorize function lotkavolterra!(dx, x, params, t)
     local α, β, γ, δ = 1.5, 1., 3., 1.


### PR DESCRIPTION
The first commit has a change that was automatically applied when I built the docs.

For the second commit, I got the following errors:

```julia
┌ Warning: failed to run `@example` block in src/tutorials/set_representations/zonotopes.md:32-36
│ ```@example zonotope_definition
│ @show center(Z)
│ 
│ @show genmat(Z)
│ ```
│   c.value = UndefVarError: center not defined
└ @ Documenter.Expanders ~/.julia/packages/Documenter/qdbx6/src/Expanders.jl:591
┌ Warning: failed to run `@example` block in src/tutorials/set_representations/zonotopes.md:40-42
│ ```@example
│ Z3 = Zonotope([1.0, 0.0], [0.1 0.0; 0.0 0.1])
│ ```
│   c.value = UndefVarError: Zonotope not defined
└ @ Documenter.Expanders ~/.julia/packages/Documenter/qdbx6/src/Expanders.jl:591
┌ Warning: failed to run `@example` block in src/tutorials/set_representations/zonotopes.md:50-55
│ ```@example zonotope_example_1
│ 
│ Z = Zonotope([1, 1.], [-1 0.3 1.5 0.3; 0 0.1 -0.3 0.3])
│ plot(Z)
│ quiver!(fill(1., 4), fill(1., 4), quiver=(genmat(Z)[1, :], genmat(Z)[2, :]), color=:black)
│ ```
│   c.value = UndefVarError: Zonotope not defined
``