### PR TITLE
Fix overapproximate(::TMRS, ::Zonotope, ::AbstractFloat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReachabilityAnalysis"
 uuid = "1e97bd63-91d1-579d-8e8d-501d2b57c93f"
-version = "0.16.4"
+version = "0.16.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/ReachSets/TaylorModelReachSet.jl
+++ b/src/ReachSets/TaylorModelReachSet.jl
@@ -331,7 +331,7 @@ function overapproximate(R::TaylorModelReachSet{N}, ::Type{<:Zonotope}, t::Abstr
 
     X = set(R)
     tn = t - tstart(R)  # normalize time (to TM-internal time)
-    tn = tn ∩ domain(R)  # intersection handles round-off errors
+    tn = interval(tn) ∩ domain(R)  # intersection handles round-off errors
     X_Δt = evaluate(X, tn)
     n = dim(R)
     X̂ = [TaylorModelN(X_Δt[j], zeroI, zeroBox(n), symBox(n)) for j in 1:n]


### PR DESCRIPTION
This fixes a bug introduced in #603: The time point has to be converted to an interval before intersecting with another interval.