### PR TITLE
Support new version of MathematicalSystems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReachabilityAnalysis"
 uuid = "1e97bd63-91d1-579d-8e8d-501d2b57c93f"
-version = "0.19.0"
+version = "0.20.0"
 
 [deps]
 CarlemanLinearization = "4803f6b2-022a-4c1b-a771-522a3413ec86"
@@ -39,7 +39,7 @@ IntervalArithmetic = "0.16 - 0.20"
 IntervalMatrices = "0.6 - 0.8"
 JuMP = "0.21 - 0.23, 1"
 LazySets = "1.58"
-MathematicalSystems = "0.11"
+MathematicalSystems = "0.11, 0.12"
 MultivariatePolynomials = "0.3 - 0.4"
 Optim = "0.18 - 0.20, 1"
 Parameters = "0.10 - 0.12"

--- a/src/Continuous/normalization.jl
+++ b/src/Continuous/normalization.jl
@@ -343,7 +343,7 @@ for CLC_S in (:CLCCS, :CLCDS)
             n = statedim(system)
             X = _wrap_invariant(stateset(system), n)
             U = _wrap_inputs(inputset(system), input_matrix(system))
-            $CLC_S(state_matrix(system), I(n, N), X, U)
+            $CLC_S(state_matrix(system), Id(n, one(N)), X, U)
         end
     end
 end
@@ -356,7 +356,7 @@ for (CA_S, CLC_S) in ((:CACS, :CLCCS), (:CADS, :CLCDS))
             n = statedim(system)
             X = _wrap_invariant(stateset(system), n)
             U = _wrap_inputs(affine_term(system))
-            $CLC_S(state_matrix(system), I(n, N), X, U)
+            $CLC_S(state_matrix(system), Id(n, one(N)), X, U)
         end
     end
 end
@@ -369,7 +369,7 @@ for (A_S, CLC_S) in ((:ACS, :CLCCS), (:ADS, :CLCDS))
             n = statedim(system)
             X = Universe(n)
             U = _wrap_inputs(affine_term(system))
-            $CLC_S(state_matrix(system), I(n, N), X, U)
+            $CLC_S(state_matrix(system), Id(n, one(N)), X, U)
         end
     end
 end
@@ -382,7 +382,7 @@ for (CAC_S, CLC_S) in ((:CACCS, :CLCCS), (:CACDS, :CLCDS))
             n = statedim(system)
             X = _wrap_invariant(stateset(system), n)
             U = _wrap_inputs(inputset(system), input_matrix(system), affine_term(system))
-            $CLC_S(state_matrix(system), I(n, N), X, U)
+            $CLC_S(state_matrix(system), Id(n, one(N)), X, U)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test, ReachabilityAnalysis
 using ReachabilityAnalysis: _isapprox, setrep, rsetrep,
                            DeterministicSwitching, NonDeterministicSwitching,
                            BoxEnclosure, ZonotopeEnclosure
+using LinearAlgebra
 
 # optional dependencies
 using Symbolics


### PR DESCRIPTION
This supersedes #658.

I also suggested a new minor release because `MathematicalSystems` is reexported, so dependencies of this package may break.