### PR TITLE
Fix bouncing-ball example

### DIFF
--- a/docs/src/man/hybrid.md
+++ b/docs/src/man/hybrid.md
@@ -45,8 +45,8 @@ prob = @ivp(H, z(0) ∈ Z0);
 boxdirs = BoxDirections{Float64, Vector{Float64}}(2)
 Thull = TemplateHullIntersection(boxdirs)
 
-sol = solve(prob, T=30.0,
-            alg=GLGM06(δ=0.01), # or LGG09 with template=boxdirs,
+sol = solve(prob, T=5.0,
+            alg=LGG09(δ=0.02, template=boxdirs),
             clustering_method=LazyClustering(1, convex=false),
             intersection_source_invariant_method=Thull,
             intersection_method=Thull);

--- a/src/Discretization/discretization.jl
+++ b/src/Discretization/discretization.jl
@@ -80,7 +80,9 @@ to the canonical form with the function [`normalize`](@ref).
 For references to the original papers introducing each algorithm, see the docstrings,
 e.g. `?Forward`.
 """
-function discretize(ivp::IVP, δ, alg::AbstractApproximationModel) end
+function discretize(ivp::IVP, δ, alg::AbstractApproximationModel)
+    error("discretization not implemented for the given arguments: $ivp, $alg")
+end
 
 # =========================================
 # Conservative time discretization methods


### PR DESCRIPTION
There is an error when using `GLGM06` with hybrid systems because we do not allow to *not* intersect with the source invariant anymore (`nothing` is not a valid parameter anymore because of the restriction to `AbstractIntersectionMethod`) 

https://github.com/JuliaReach/ReachabilityAnalysis.jl/blob/1456c3965df8ef37164cdc022f8d3880d883f37e/src/Hybrid/solve.jl#L12
https://github.com/JuliaReach/ReachabilityAnalysis.jl/blob/1456c3965df8ef37164cdc022f8d3880d883f37e/src/Hybrid/solve.jl#L25-L27

This means that the `else` branch below is effectively dead code:

https://github.com/JuliaReach/ReachabilityAnalysis.jl/blob/1456c3965df8ef37164cdc022f8d3880d883f37e/src/Hybrid/solve.jl#L251-L256

That lead to the bouncing ball failing because `X0` is converted to an `HPolytope`, which the discretization cannot deal with. One problem is that `discretize` did not print any error because it just uses the no-op default method. I now changed the code to at least print an error message if the discretization failed.

There is a similar error in `faq.md` (which is why the last code block [here](https://juliareach.github.io/ReachabilityAnalysis.jl/dev/man/faq/#Can-I-compute-solutions-using-parallel-programming?) is not executed). But I did not investigate if we still have an algorithm to support a `ConvexHullArray`.