### PR TITLE
Fix Pade approximation and test _exp

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -76,4 +76,4 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CDDLib", "DifferentialEquations", "FastExpm", "Flowstar", "JuMP", "Plots", "Polyhedra", "SparseArrays", "Symbolics", "Test"]
+test = ["CDDLib", "DifferentialEquations", "Expokit", "FastExpm", "Flowstar", "JuMP", "Plots", "Polyhedra", "SparseArrays", "Symbolics", "Test"]

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -121,6 +121,9 @@ function __init__()
     # sparse dynamic representation of multivariate polynomials
     @require DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07" include("init_DynamicPolynomials.jl")
 
+    # exponentiation methods using Krylov subspace and Padé approximations
+    @require Expokit = "a1e7a1ef-7a5d-5822-a38c-be74e1bb89f4" include("init_Expokit.jl")
+
     # exponentiation methods using Krylov subspace approximations
     @require ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18" include("init_ExponentialUtilities.jl")
 

--- a/src/Initialization/init_Expokit.jl
+++ b/src/Initialization/init_Expokit.jl
@@ -1,0 +1,1 @@
+eval(load_expokit_pade())

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -1,0 +1,24 @@
+using SparseArrays
+using ReachabilityAnalysis: _exp
+
+@testset "Exponentiation" begin
+    A = [10.0 0; 0 20]
+    δ = 0.1
+    expAδ = [exp(1) 0; 0 exp(2)]
+
+    # default algorithm
+    @test _exp(A, δ) == expAδ
+
+    # base algorithm
+    @test _exp(A, δ, RA.BaseExpAlg()) == expAδ
+
+    # Krylov algorithm
+    @test _exp(sparse(A), δ, RA.LazyExpAlg()) == expAδ
+
+    # interval matrix
+    @test all((_exp(A, δ, RA.IntervalExpAlg()) .- IntervalMatrix(expAδ)) .<= 1e-4)
+
+    # Padé approximation
+    @test_throws ArgumentError _exp(A, δ, RA.PadeExpAlg())
+    @test _exp(sparse(A), δ, RA.PadeExpAlg()) ≈ expAδ
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using StaticArrays
 using Polyhedra, CDDLib # for VREP algorithm
 import TaylorModels # for TMJets algorithm
 import Flowstar # for FLOWSTAR algorithm
+import Expokit # for Padé approximation
 
 # fix namespace conflicts with Polyhedra
 using LazySets: dim, HalfSpace, Interval, Line2D, translate, project
@@ -35,6 +36,7 @@ include("models/generated/Brusselator.jl")
 include("models/hybrid/thermostat.jl")
 
 include("solve.jl")
+include("discretization.jl")
 include("reachsets.jl")
 include("flowpipes.jl")
 include("traces.jl")


### PR DESCRIPTION
In `master`:

```julia
julia> using ReachabilityAnalysis, SparseArrays

julia> using ReachabilityAnalysis: _exp, PadeExpAlg

julia> A = sparse([10.0 0; 0 20]); δ = 0.1;

julia> _exp(A, δ, PadeExpAlg())
ERROR: AssertionError: package `Expokit` is required for this function; do `using Expokit` and try again

julia> using Expokit

julia> _exp(A, δ, PadeExpAlg())
ERROR: AssertionError: package `Expokit` is required for this function; do `using Expokit` and try again
```