### PR TITLE
Remove internal concrete sih

### DIFF
--- a/src/Discretization/Forward.jl
+++ b/src/Discretization/Forward.jl
@@ -97,7 +97,7 @@ function discretize(ivp::IVP{<:CLCS,Interval{N}}, δ, alg::Forward) where {N}
     #Einit = (P2A_abs * a_sqr) * RA._symmetric_interval_hull(X0).dat
 
     #P2A_abs = (1/a_sqr) * (Φ - one(N) - aδ)
-    Einit = (Φ - one(N) - aδ) * convert(Interval, _symmetric_interval_hull(X0)).dat
+    Einit = (Φ - one(N) - aδ) * convert(Interval, symmetric_interval_hull(X0)).dat
 
     Ω0 = Interval(hull(X0.dat, Φ * X0.dat + Einit))
     X = stateset(ivp)

--- a/src/Discretization/discretization.jl
+++ b/src/Discretization/discretization.jl
@@ -19,7 +19,7 @@ hasbackend(alg::AbstractApproximationModel) = false
 
 # symmetric interval hull options
 sih(X, ::Val{:lazy}) = SymmetricIntervalHull(X)
-sih(X, ::Val{:concrete}) = _symmetric_interval_hull(X)
+sih(X, ::Val{:concrete}) = symmetric_interval_hull(X)
 
 # interval matrix functions
 isinterval(A::AbstractMatrix{N}) where {N<:Number} = false

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -364,19 +364,6 @@ function _split(A::IntervalMatrix{T,IT,MT}) where {T,IT,ST,MT<:StaticArray{ST,IT
     return SMatrix{m,n,T}(C), SMatrix{m,n,T}(S)
 end
 
-_symmetric_interval_hull(x::Interval) = LazySets.symmetric_interval_hull(x)
-_symmetric_interval_hull(x::Hyperrectangle) = LazySets.symmetric_interval_hull(x)
-
-# type-stable version
-function _symmetric_interval_hull(S::LazySet{N}) where {N}
-    # fallback returns a hyperrectangular set
-    (c, r) = box_approximation_helper(S)
-    #if r[1] < 0
-    #    return EmptySet{N}(dim(S))
-    #end
-    return Hyperrectangle(zeros(N, length(c)), abs.(c) .+ r)
-end
-
 # type-stable version
 function _overapproximate(S::LazySet{N}, ::Type{<:Hyperrectangle}) where {N}
     c, r = box_approximation_helper(S)


### PR DESCRIPTION
Prelim for https://github.com/JuliaReach/ReachabilityAnalysis.jl/pull/753

This simplifies `setops.jl` a bit by removing an internal method.