### PR TITLE
Merge code for overapproximate of TaylorModelReachSet

### DIFF
--- a/test/reachsets/reachsets.jl
+++ b/test/reachsets/reachsets.jl
@@ -157,7 +157,7 @@ end
     @test isequivalent(ConvexHullArray(set.(Z)), set(Z0))
 end
 
-@testset "Overapproximation of a Taylor model reach-sets II" begin
+@testset "Overapproximation of Taylor model reach-sets II" begin
 
     # Two dimensional
     # ------------------


### PR DESCRIPTION
1. The methods
```julia
function _overapproximate(R::TaylorModelReachSet{N}, ::Type{<:Hyperrectangle};
                          Δt::TimeInterval=tspan(R), dom=symBox(dim(R))) where {N}
function _overapproximate(R::TaylorModelReachSet{N}, ::Type{<:Zonotope};
                          Δt::TimeInterval=tspan(R), dom=symBox(dim(R))) where {N}
```
only differed in the last line (modulo reordering of other lines).

2. The method
```julia
function overapproximate(R::TaylorModelReachSet{N}, ::Type{<:Zonotope}, t::AbstractFloat;
                         remove_zero_generators=true) where {N}
```
was almost identical too; now it calls the common method above instead. Furthermore, a method for time points and `Hyperrectangle` was not available; now it is.

3. I added a TODO to outsource some code to `LazySets`. I already added a PR for that here:
JuliaReach/LazySets.jl/pull/3432