### PR TITLE
Fix ambiguities

### DIFF
--- a/docs/src/tutorials/linear_methods/discrete_time.md
+++ b/docs/src/tutorials/linear_methods/discrete_time.md
@@ -47,7 +47,7 @@ V = vertices_list(X0) .|> Singleton |> UnionSetArray
 plot!(c)
 plot!(V)
 plot!(M(pi/4) * c) # rotate 45 degrees
-plot!(M(pi/4) * V)
+plot!(linear_map(M(pi/4), V))
 
 xlims!(0.0, 1.8) # hide
 ylims!(-0.4, 1.4) # hide
@@ -60,9 +60,9 @@ fig = DisplayAs.Text(DisplayAs.PNG(fig))  # hide
 X = sample(X0, 25) .|> Singleton |> UnionSetArray
 
 plot!(X)
-plot!(M(pi/4) * X, c=:blue)     # rotate 45 degrees
-plot!(M(pi/2) * X, c=:green)    # rotate 90 degrees
-plot!(M(4pi/3) * X, c=:orange)  # rotate 180 degrees
+plot!(linear_map(M(pi/4), X), c=:blue)     # rotate 45 degrees
+plot!(linear_map(M(pi/2), X), c=:green)    # rotate 90 degrees
+plot!(linear_map(M(4pi/3), X), c=:orange)  # rotate 180 degrees
 
 plot!(X0, c=:white)
 plot!(M(pi/4) * X0, c=:white)

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -281,30 +281,6 @@ end
     return !_geq(q, min(X)) || !_leq(q, max(X))
 end
 
-# if X is polyhedral and Y is the set union of half-spaces, X ∩ Y is empty iff
-# X ∩ Hi is empty for each half-space Hi in Y
-# NOTE the algorithm below solves an LP for each X ∩ Hi; however, we can proceed
-# more efficiently using support functions
-# see LazySets.is_intersection_empty_helper_halfspace
-@commutative function isdisjoint(X::AbstractPolytope{N},
-                                 Y::UnionSetArray{N,<:HalfSpace{N}}) where {N}
-    if dim(X) == 2 # use vrep in 2D
-        Xp = convert(VPolygon, X)
-        return all(Yi -> isdisjoint(Xp, Yi), array(Y))
-    end
-
-    clist_X = constraints_list(X)
-    for ci in Y.array
-        # using support functions
-        #!(-ρ(-hs.a, X) > hs.b) && return false # TODO use robust check
-
-        # using LP
-        Y_ci = vcat(clist_X, ci)
-        remove_redundant_constraints!(Y_ci) && return false
-    end
-    return true
-end
-
 # ====================================================================
 # Concrete intersection
 #

--- a/src/Flowpipes/setops.jl
+++ b/src/Flowpipes/setops.jl
@@ -217,10 +217,6 @@ function _split_symmetric_box(D::Int, partition::Vector{Int})
     return convert.(IA.IntervalBox, Sp)
 end
 
-function Base.:(*)(M::AbstractMatrix, X::UnionSetArray{N,<:AbstractSingleton{N}}) where {N}
-    return UnionSetArray([linear_map(M, p) for p in array(X)])
-end
-
 # ==================================
 # Zonotope order reduction methods
 # ==================================


### PR DESCRIPTION
See #788. Four ambiguities remain.

EDIT: The first commits have been outsourced to #811 and merged. This branch is now rebased.
~~The first commit makes changes that should be clear.~~
The other commits change/remove behaviors. But I would argue that we do not need these anymore now that unions are `LazySet`s, and some methods have been questionable.