### PR TITLE
Define `box_approximation` for `AbstractReachSet`s and `AbstractFlowpipe`s

### DIFF
--- a/src/Flowpipes/AbstractFlowpipe.jl
+++ b/src/Flowpipes/AbstractFlowpipe.jl
@@ -259,3 +259,9 @@ end
 
 Base.:⊆(F::AbstractFlowpipe, X::LazySet) = all(R ⊆ X for R in F)
 Base.:⊆(F::AbstractFlowpipe, Y::AbstractLazyReachSet) = all(R ⊆ set(Y) for R in F)
+
+# ------------------------------
+# Methods to overapproximate
+# ------------------------------
+
+box_approximation(F::AbstractFlowpipe; kwargs...) = overapproximate(F, Hyperrectangle; kwargs...)

--- a/src/ReachSets/AbstractReachSet.jl
+++ b/src/ReachSets/AbstractReachSet.jl
@@ -297,3 +297,9 @@ end
                                     method::AbstractIntersectionMethod)
     return _intersection(set(R), X, method)
 end
+
+# ------------------------------
+# Methods to overapproximate
+# ------------------------------
+
+box_approximation(R::AbstractReachSet; kwargs...) = overapproximate(R, Hyperrectangle; kwargs...)


### PR DESCRIPTION
An alternative would be to let `LazySets` define `box_approximation` without type restrictions.
EDIT: `LazySets` actually defines it the other way around:
`overapproximate(S::LazySet, ::Type{<:Hyperrectangle}) = box_approximation(S)`
Nevertheless, the point remains.

If not, we should probably still use the same convention here and rename all methods to `box_approximation` (and then add an alias with `overapproximate`).