### PR TITLE
Outsource code to LazySets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ ExprTools = "0.1"
 HybridSystems = "0.4"
 IntervalArithmetic = "0.16 - 0.20, =0.20.9"  # new versions require updates and are incompatible with dependencies
 IntervalMatrices = "0.6 - 0.10"
-LazySets = "2.11"
+LazySets = "2.12"
 LinearAlgebra = "<0.0.1, 1.6"
 MathematicalSystems = "0.11 - 0.13"
 Parameters = "0.10 - 0.12"


### PR DESCRIPTION
This fixes some piracies (see #790).

Again the docs build does not see the latest LazySets release, while the test build sees it. I think I now understand why this happens - I had the same problem when doing `dev ..` from the `docs/` project. In any case, I ran the docs build locally and it passed.