### PR TITLE
Remove `basetype` (available in ReachabilityBase)

### DIFF
--- a/docs/src/lib/flowpipes.md
+++ b/docs/src/lib/flowpipes.md
@@ -14,7 +14,6 @@ AbstractFlowpipe
 The following functions are available at the interface level.
 
 ```@docs
-basetype(::Type{<:AbstractFlowpipe})
 LazySets.ρ(::AbstractVector, ::AbstractFlowpipe)
 LazySets.σ(::AbstractVector, ::AbstractFlowpipe)
 LazySets.dim(::AbstractFlowpipe)

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -24,11 +24,3 @@ Depth = 3
 ```@docs
 _default_cpost
 ```
-
-## Documentation fixes
-
-The following duplicated documentation is necessary due to a problem in the `Documenter` package.
-
-```@docs
-basetype
-```

--- a/docs/src/lib/reachsets.md
+++ b/docs/src/lib/reachsets.md
@@ -14,7 +14,6 @@ AbstractReachSet
 The functions are available at the interface level.
 
 ```@docs
-basetype(::Type{<:AbstractReachSet})
 set(::AbstractReachSet)
 setrep(::AbstractReachSet)
 tspan(::AbstractReachSet)

--- a/src/Flowpipes/AbstractFlowpipe.jl
+++ b/src/Flowpipes/AbstractFlowpipe.jl
@@ -13,22 +13,6 @@ A flowpipe is the set union of an array of reach-sets.
 """
 abstract type AbstractFlowpipe end
 
-"""
-    basetype(T::Type{<:AbstractFlowpipe})
-
-Return the base type of the given flowpipe type (i.e., without type parameters).
-
-### Input
-
-- `T` -- flowpipe type, used for dispatch
-
-### Output
-
-The base type of `T`.
-"""
-basetype(T::Type{<:AbstractFlowpipe}) = Base.typename(T).wrapper
-basetype(fp::AbstractFlowpipe) = basetype(typeof(fp))
-
 # LazySets interface: fallback behaves like UnionSetArray
 
 """

--- a/src/ReachSets/AbstractReachSet.jl
+++ b/src/ReachSets/AbstractReachSet.jl
@@ -38,21 +38,6 @@ const SetOrReachSet = Union{LazySet,UnionSet,UnionSetArray,IA.Interval,IA.Interv
                             AbstractReachSet}
 
 """
-    basetype(T::Type{<:AbstractReachSet})
-
-Return the base type of the given reach-set type (i.e., without type parameters).
-
-### Input
-
-- `T` -- reach-set type, used for dispatch
-
-### Output
-
-The base type of `T`.
-"""
-basetype(T::Type{<:AbstractReachSet}) = Base.typename(T).wrapper
-
-"""
     set(R::AbstractReachSet)
 
 Return the geometric set represented by this reach-set.

--- a/test/flowpipes/flowpipes.jl
+++ b/test/flowpipes/flowpipes.jl
@@ -8,7 +8,6 @@ using ReachabilityAnalysis: _isapprox
 
     # base, numeric, set and reach-set types
     FT = typeof(fp)
-    @test basetype(FT) == basetype(fp) == Flowpipe
     N = ReachabilityAnalysis.numtype(fp)
     @test N == Float64
     ZT = Zonotope{N,Vector{N},Matrix{N}}


### PR DESCRIPTION
The function was actually never used.