### PR TITLE
Add discrete post for `GLGM06`

### DIFF
--- a/src/Algorithms/GLGM06/post.jl
+++ b/src/Algorithms/GLGM06/post.jl
@@ -1,8 +1,7 @@
 # continuous post for GLGM06 using Zonotope set representation
 function post(alg::GLGM06{N}, ivp::IVP{<:AbstractContinuousSystem}, tspan;
               Δt0::TimeInterval=zeroI, kwargs...) where {N}
-    @unpack δ, approx_model, max_order, static, dim, ngens,
-    preallocate, reduction_method, disjointness_method = alg
+    δ = alg.δ
 
     # TODO move up to main solve function
     if haskey(kwargs, :NSTEPS)
@@ -25,13 +24,30 @@ function post(alg::GLGM06{N}, ivp::IVP{<:AbstractContinuousSystem}, tspan;
     end
 
     # discretize system
-    ivp_discr = discretize(ivp_norm, δ, approx_model)
-    Φ = state_matrix(ivp_discr)
-    Ω0 = initial_state(ivp_discr)
-    X = stateset(ivp_discr)
+    ivp_discr = discretize(ivp_norm, δ, alg.approx_model)
+
+    return post(alg, ivp_discr, NSTEPS; Δt0=Δt0, kwargs...)
+end
+
+function post(alg::GLGM06{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
+              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+    @unpack δ, approx_model, max_order, static, dim, ngens,
+    preallocate, reduction_method, disjointness_method = alg
+
+    if isnothing(NSTEPS)
+        if haskey(kwargs, :NSTEPS)
+            NSTEPS = kwargs[:NSTEPS]
+        else
+            throw(ArgumentError("`NSTEPS` not specified"))
+        end
+    end
+
+    Φ = state_matrix(ivp)
+    Ω0 = initial_state(ivp)
+    X = stateset(ivp)
 
     # true <=> there is no input, i.e. the system is of the form x' = Ax, x ∈ X
-    got_homogeneous = !hasinput(ivp_discr)
+    got_homogeneous = !hasinput(ivp)
 
     # this algorithm requires Ω0 to be a zonotope
     Ω0 = _convert_or_overapproximate(Zonotope, Ω0)
@@ -62,7 +78,7 @@ function post(alg::GLGM06{N}, ivp::IVP{<:AbstractContinuousSystem}, tspan;
                             disjointness_method)
     else
         # TODO: implement preallocate option for this scenario
-        U = inputset(ivp_discr)
+        U = inputset(ivp)
         @assert isa(U, LazySet) "expected input of type `<:LazySet`, but got $(typeof(U))"
         U = _convert_or_overapproximate(Zonotope, U)
         U = _reconvert(U, static, dim, ngens)

--- a/test/algorithms/GLGM06.jl
+++ b/test/algorithms/GLGM06.jl
@@ -1,12 +1,19 @@
 @testset "GLGM06 algorithm: homogeneous" begin
 
     # one-dimensional
-    prob, _ = exponential_1d()
-    sol = solve(prob; T=5.0, alg=GLGM06(; δ=0.01))
+    ivp, _ = exponential_1d()
+    alg = GLGM06(; δ=0.01)
+    # continuous algorithm
+    sol = solve(ivp; T=5.0, alg=alg)
     @test isa(sol.alg, GLGM06)
     @test setrep(sol) <: Zonotope
     @test setrep(sol) == Zonotope{Float64,Array{Float64,1},Array{Float64,2}}
     @test dim(sol) == 1
+    # discrete algorithm
+    ivp_norm = ReachabilityAnalysis._normalize(ivp)
+    ivp_discr = discretize(ivp_norm, alg.δ, alg.approx_model)
+    NSTEPS = 500
+    fp_d = ReachabilityAnalysis.post(alg, ivp_discr, NSTEPS)
 
     # higher-dimensional homogeneous
     prob, _ = linear5D_homog()


### PR DESCRIPTION
This is an example how to add discrete post functions for the linear algorithms. 
`solve` is not implemented yet.

```julia
function exponential_1d(; invariant=Universe(1))
  s = @system(x' = -x, x ∈ invariant)
  x0 = Interval(0.4, 0.5)
  prob = InitialValueProblem(s, x0)
  tspan = (0.0, 1.0)
  return prob, tspan
end
ivp, _ = exponential_1d()
alg = GLGM06(; δ=0.01)

sol_c = solve(ivp; T=5.0, alg=alg);

ivp_norm = ReachabilityAnalysis._normalize(ivp)
ivp_discr = discretize(ivp_norm, alg.δ, alg.approx_model)
NSTEPS = 500

fp_d = ReachabilityAnalysis.post(alg, ivp_discr, NSTEPS);
```
At the end, `flowpipe(sol_c) == fp_d` would hold, but `==` is not defined for flowpipes.