### PR TITLE
Use `scale` for linear map with `IdentityMultiple`

### DIFF
--- a/src/Continuous/normalization.jl
+++ b/src/Continuous/normalization.jl
@@ -507,7 +507,7 @@ end
 _wrap_invariant(X::LazySet, ::Int) = X
 _wrap_invariant(::Nothing, n::Int) = Universe(n)
 
-_wrap_inputs(U::AbstractInput, B::IdentityMultiple) = isidentity(B) ? U : map(u -> B * u, U)
+_wrap_inputs(U::AbstractInput, B::IdentityMultiple) = isidentity(B) ? U : map(u -> scale(B.M.λ, u), U)
 _wrap_inputs(U::AbstractInput, B::AbstractMatrix) = map(u -> B * u, U)
 
 function _wrap_inputs(U::LazySet, B::IdentityMultiple)

--- a/test/algorithms/BOX.jl
+++ b/test/algorithms/BOX.jl
@@ -18,13 +18,20 @@
     A = hcat(state_matrix(ivp))
     X = stateset(ivp)
     X0 = initial_state(ivp)
-    B = Id(1, 1.0)  # TODO implement for different multiple
-    U = ConstantInput(Singleton([0.0]))
+    B = Id(1, 1.0)
+    U = ConstantInput(Singleton([1.0]))
     ivp2 = @ivp(ConstrainedLinearControlContinuousSystem(A, B, X, U), X(0) ∈ X0)
     sol2 = solve(ivp2; tspan=(0.0, 1.0), alg=alg, homogenize=true)
     @test isa(sol2.alg, BOX)
     @test setrep(sol2) == Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}
     @test dim(sol2) == 2
+    # multiple of identity
+    B = Id(1, 2.0)
+    ivp3 = @ivp(ConstrainedLinearControlContinuousSystem(A, B, X, U), X(0) ∈ X0)
+    sol3 = solve(ivp3; tspan=(0.0, 1.0), alg=alg, homogenize=true)
+    @test isa(sol3.alg, BOX)
+    @test setrep(sol3) == Hyperrectangle{Float64,Array{Float64,1},Array{Float64,1}}
+    @test dim(sol3) == 2
 
     # higher-dimensional homogeneous
     ivp, tspan = linear5D_homog()


### PR DESCRIPTION
This fixes an issue uncovered in #889.

The proposed change assumes that `scale` is available for the input set. This currently holds at least for the common input sets (`Singleton`, `Hyperrectangle`, `Zonotope`).