### PR TITLE
Define `==` for reach sets, flowpipes, `ReachSolution`

### DIFF
--- a/src/Flowpipes/AbstractFlowpipe.jl
+++ b/src/Flowpipes/AbstractFlowpipe.jl
@@ -85,6 +85,8 @@ end
 @inline Base.lastindex(fp::AbstractFlowpipe) = length(array(fp))
 @inline Base.eachindex(fp::AbstractFlowpipe) = eachindex(array(fp))
 
+Base.:(==)(fp1::AbstractFlowpipe, fp2::AbstractFlowpipe) = array(fp1) == array(fp2)
+
 # fallback implementations of set getter functions
 
 """

--- a/src/Flowpipes/solutions.jl
+++ b/src/Flowpipes/solutions.jl
@@ -87,6 +87,8 @@ rsetrep(sol::ReachSolution{FT,ST}) where {FT,ST} = rsetrep(FT)
 vars(sol::ReachSolution) = vars(sol.F)
 numrsets(sol::ReachSolution) = numrsets(sol.F)
 
+Base.:(==)(sol1::ReachSolution, sol2::ReachSolution) = flowpipe(sol1) == flowpipe(sol2)
+
 # iteration and indexing iterator interface
 array(sol::ReachSolution) = array(sol.F)
 Base.iterate(sol::ReachSolution) = iterate(sol.F)

--- a/src/ReachSets/AbstractReachSet.jl
+++ b/src/ReachSets/AbstractReachSet.jl
@@ -167,6 +167,10 @@ function LazySets.dim(::AbstractReachSet) end
 # for internal use (dimensional checks in solve)
 _dim(X::AbstractReachSet) = dim(X)
 
+function Base.:(==)(R1::AbstractReachSet, R2::AbstractReachSet)
+    return tspan(R1) == tspan(R2) && set(R1) == set(R2)
+end
+
 """
     copy(R::AbstractReachSet)
 

--- a/test/flowpipes/flowpipes.jl
+++ b/test/flowpipes/flowpipes.jl
@@ -14,6 +14,12 @@ using ReachabilityAnalysis: _isapprox
     @test setrep(FT) == ZT
     @test rsetrep(fp) == ReachSet{N,ZT}
 
+    # equality
+    sol2 = solve(prob; tspan=dt)
+    fp2 = flowpipe(sol2)
+    @test fp == fp2
+    @test sol == sol2
+
     # ambient dimension
     @test dim(fp) == 2
 

--- a/test/reachsets/reachsets.jl
+++ b/test/reachsets/reachsets.jl
@@ -17,6 +17,10 @@ using TaylorModels: set_variables,
     # if the time is an integer, it is converted to a float
     R = ReachSet(X, 1)
     @test tspan(R) == interval(1.0)
+
+    # equality
+    R2 = ReachSet(X, 1)
+    @test R == R2
 end
 
 @testset "Reach-set projections" begin


### PR DESCRIPTION
Maybe the definition for the interfaces is too strong and should be added only for the standard types `ReachSet` and `Flowpipe`?