### PR TITLE
Allow Polyhedra v0.8 and CDDLib v0.10 in tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -18,14 +18,14 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8.9"
-CDDLib = "0.5 - 0.9"
+CDDLib = "0.5 - 0.10"
 Expokit = "0.2"
 Flowstar = "0.2.4"
 IntervalArithmetic = "0.16 - 0.20, =0.20.9"  # new versions require updates and are incompatible with dependencies
 LazySets = "2.14, 3"
 Optim = "0.15 - 0.22, 1"
 OrdinaryDiffEq = "6"
-Polyhedra = "0.5 - 0.7"
+Polyhedra = "0.5 - 0.8"
 StaticArrays = "0.12, 1"
 Suppressor = "0.2"
 Symbolics = "4 - 6"


### PR DESCRIPTION
Closes #894.
Closes #895.