### PR TITLE
#900 - Fix `FirstOrderZonotopeModule` for zero matrix

### DIFF
--- a/src/Discretization/FirstOrderZonotopeModule.jl
+++ b/src/Discretization/FirstOrderZonotopeModule.jl
@@ -5,6 +5,7 @@ module FirstOrderZonotopeModule
 
 using ..DiscretizationModule
 using ..Exponentiation: _exp, BaseExp
+using ReachabilityBase.Comparison: isapproxzero
 using LinearAlgebra
 using MathematicalSystems
 using LazySets
@@ -103,7 +104,7 @@ function discretize(ivp::IVP{<:CLCCS,<:AbstractZonotope}, δ, alg::FirstOrderZon
     # compute bloating factor β
     U = next_set(inputset(ivp), 1)
     μ = norm(U, Inf)
-    β = ((exp(norm_A * δ) - 1) * μ) / norm_A
+    β = isapproxzero(norm_A) ? μ * δ : ((exp(norm_A * δ) - 1) * μ) / norm_A
 
     # compute bloating of Z
     Ω0 = minkowski_sum(Z, BallInf(zeros(n), α + β))


### PR DESCRIPTION
See #900.