### PR TITLE
Fix `@system` for v1.12 parser restrictions

### DIFF
--- a/docs/src/man/faq.md
+++ b/docs/src/man/faq.md
@@ -171,7 +171,7 @@ position, `x(t)`, and the second coordinate to velocity, `x'(t)`.
 !!! note
     Usual Julia vectors such as `X0 = [1.0, 0.0]` are also valid input, and are
     treated as a singleton. It is also valid to use tuples in second order systems,
-    e.g. `prob = @ivp(X' = AX, X(0) ∈ ([1.0], [0.0]))`.
+    e.g. `prob = @ivp(X' = A * X, X(0) ∈ ([1.0], [0.0]))`.
 
 Below we plot the flowpipe for the same initial condition and different step
 sizes.
@@ -183,7 +183,7 @@ using ReachabilityAnalysis, Plots
 # v' = -4x
 A = [0 1; -4. 0]
 X0 = Singleton([1.0, 0.0])
-prob = @ivp(X' = AX, X(0) ∈ X0)
+prob = @ivp(X' = A * X, X(0) ∈ X0)
 
 f(ΔT) = solve(prob, tspan=(0.0, 5.0), alg=GLGM06(δ=ΔT))
 
@@ -258,7 +258,7 @@ using ReachabilityAnalysis, Plots
 A = [0.0 1.0; -1.0 0.0]
 
 B = [BallInf([0,0.] .+ k, 0.1) for k in 1:5]
-prob = @ivp(x' = Ax, x(0) ∈ B)
+prob = @ivp(x' = A * x, x(0) ∈ B)
 
 # multi-threaded solve
 sol = solve(prob, T=12.0, alg=GLGM06(δ=0.02));
@@ -272,7 +272,7 @@ a single integration the flowpipe corresponding to the convex hull of the elemen
 in the array `B`.
 
 ```@example parallel
-prob = @ivp(x' = Ax, x(0) ∈ ConvexHullArray(B))
+prob = @ivp(x' = A * x, x(0) ∈ ConvexHullArray(B))
 sol = solve(prob, T=12.0, alg=GLGM06(δ=0.02, approx_model=Forward()));
 plot!(sol, vars=(0, 2), c=:lightgreen, alpha=.5, lw=0.2, xlab="t", ylab="y")
 

--- a/examples/OpAmp/OpAmp.jl
+++ b/examples/OpAmp/OpAmp.jl
@@ -176,9 +176,9 @@ function opamp_with_saturation(; X0=Singleton(zeros(2)),
     ## modes
     A = [α β; 0 γ]
     b = [0; δ]
-    mode1 = @system(x' = Ax + b, x ∈ HalfSpace(ein <= Es, var))
+    mode1 = @system(x' = A * x + b, x ∈ HalfSpace(ein <= Es, var))
     A = [α β; 0 0]
-    mode2 = @system(x' = Ax, x ∈ Universe(2))
+    mode2 = @system(x' = A * x, x ∈ Universe(2))
     modes = [mode1, mode2]
 
     ## transition mode1 -> mode2 (saturation)

--- a/src/Algorithms/CARLIN/reach.jl
+++ b/src/Algorithms/CARLIN/reach.jl
@@ -21,7 +21,7 @@ function reach_CARLIN(X0, F1, F2; alg, N, T, Δt, bloat, compress, A=nothing)
     if isnothing(A)
         A = build_matrix(F1, F2, N; compress)
     end
-    prob = @ivp(ŷ' = Aŷ, ŷ(0) ∈ ŷ0)
+    prob = @ivp(ŷ' = A * ŷ, ŷ(0) ∈ ŷ0)
     sol = solve(prob; T=T, alg=alg, Δt0=Δt)
 
     # projection onto the first n variables

--- a/test/algorithms/ASB07.jl
+++ b/test/algorithms/ASB07.jl
@@ -7,7 +7,7 @@ using ReachabilityAnalysis.Exponentiation: IntervalExpAlg
     A = IntervalMatrix([-1.0±0.05 -4.0±0.05;
                         4.0±0.05 -1.0±0.05])
     X0 = BallInf([1.0, 1.0], 0.1)
-    ivp = @ivp(x' = Ax, x(0) ∈ X0)
+    ivp = @ivp(x' = A * x, x(0) ∈ X0)
     alg = ASB07(; δ=0.04)
 
     # continuous algorithm
@@ -53,7 +53,7 @@ using ReachabilityAnalysis.Exponentiation: IntervalExpAlg
     # TODO test without IntervalMatrix wrapper
     #A = [-1.0 ± 0.05 -4.0 ± 0.05;
     #     4.0 ± 0.05 -1.0 ± 0.05]
-    #ivp = @ivp(x' = Ax, x(0) ∈ X0)
+    #ivp = @ivp(x' = A * x, x(0) ∈ X0)
     #sol1 = solve(ivp, tspan=(0.0, 1.0), alg=ASB07(δ=0.04));
 end
 
@@ -64,7 +64,7 @@ end
     B = hcat([1.0 ± 0.01; 1.0 ± 0.0])
     U = Interval(-0.05, 0.05)
     X0 = BallInf([1.0, 1.0], 0.1)
-    ivp = @ivp(x' = Ax + Bu, x(0) ∈ X0, u ∈ U, x ∈ Universe(2))
+    ivp = @ivp(x' = A * x + Bu, x(0) ∈ X0, u ∈ U, x ∈ Universe(2))
     sol1 = solve(ivp; tspan=(0.0, 1.0), alg=ASB07(; δ=0.04))
 end
 

--- a/test/algorithms/LGG09.jl
+++ b/test/algorithms/LGG09.jl
@@ -77,7 +77,7 @@ end
     X0 = BallInf([1.0, 1.0], 0.1)
     function foo()
         A = [0.0 1.0; -1.0 0.0]
-        ivp = @ivp(x' = Ax, x(0) ∈ X0)
+        ivp = @ivp(x' = A * x, x(0) ∈ X0)
         tspan = (0.0, 20.0)
         return ivp, tspan
     end

--- a/test/continuous/symbolics.jl
+++ b/test/continuous/symbolics.jl
@@ -5,7 +5,7 @@ using ReachabilityAnalysis: _jacobian_function,
                             _hessian_expression
 using StaticArrays: SVector, SMatrix, SA, StaticArray
 
-@testset "Symbolic-Numeric utils: Jacobian" begin
+@testset "Symbolic-numeric utils: Jacobian" begin
     # Brusselator model as a vector of symbolic expressions
     var = @variables x y
     f = [1 + x^2 * y - 2.5x, 1.5x - x^2 * y]
@@ -50,7 +50,7 @@ using StaticArrays: SVector, SMatrix, SA, StaticArray
 
     # linear systems
     A = [1 3; 2 -2.0]
-    sys = @system(x' = Ax)
+    sys = @system(x' = A * x)
     J = _jacobian_function(sys, var)
     aux = [1.0, 1.0] # can be any vector
     @test J(aux) == A

--- a/test/models/EMBrake.jl
+++ b/test/models/EMBrake.jl
@@ -19,7 +19,7 @@ function embrake_no_pv(; Tsample=1.E-4, ζ=1e-6, x0=0.05)
                 0 0 0 0;
                 0 0 0 0])
 
-    EMbrake = @system(x' = Ax)
+    EMbrake = @system(x' = A * x)
 
     # initial conditions
     I₀  = Singleton([0.0])
@@ -57,7 +57,7 @@ function embrake_pv_1(; Tsample=1.E-4, ζ=1e-6, Δ=3.0, x0=0.05)
                         0 0 0 0;
                         0 0 0 0])
 
-    EMbrake = @system(x' = Ax)
+    EMbrake = @system(x' = A * x)
 
     # initial conditions
     I₀  = Singleton([0.0])
@@ -95,7 +95,7 @@ function embrake_pv_2(; Tsample=1.E-4, ζ=1e-6, x0=0.05, χ=5.0)
                         0 0 0 0;
                         0 0 0 0])
 
-    EMbrake = @system(x' = Ax)
+    EMbrake = @system(x' = A * x)
 
     # initial conditions
     I₀  = Singleton([0.0])

--- a/test/models/generated/OpAmp.jl
+++ b/test/models/generated/OpAmp.jl
@@ -37,9 +37,9 @@ function opamp_with_saturation(; X0=Singleton(zeros(2)),
     # modes
     A = [α β; 0 γ]
     b = [0; δ]
-    mode1 = @system(x' = Ax + b, x ∈ HalfSpace(ein <= Es, var))
+    mode1 = @system(x' = A * x + b, x ∈ HalfSpace(ein <= Es, var))
     A = [α β; 0 0]
-    mode2 = @system(x' = Ax, x ∈ Universe(2))
+    mode2 = @system(x' = A * x, x ∈ Universe(2))
     modes = [mode1, mode2]
 
     # transition mode1 -> mode2 (saturation)

--- a/test/models/harmonic_oscillator.jl
+++ b/test/models/harmonic_oscillator.jl
@@ -1,6 +1,6 @@
 function harmonic_oscillator(; X=Universe(2))
     A = [0.0 1.0; -1.0 0.0]
-    prob = @ivp(x' = Ax, x(0) ∈ Singleton([1.0, 0.0]), x ∈ X)
+    prob = @ivp(x' = A * x, x(0) ∈ Singleton([1.0, 0.0]), x ∈ X)
     tspan = (0.0, 20.0)
     return prob, tspan
 end

--- a/test/models/linear/interval2D.jl
+++ b/test/models/linear/interval2D.jl
@@ -10,11 +10,11 @@ A = IntervalMatrix([-1.0±0.05 -4.0±0.05;
                     4.0±0.05 -1.0±0.05])
 
 # IVP(LCS(A), X0) TODO: remove
-interval2D_linear = @ivp x' = Ax, x(0) ∈ X0
+interval2D_linear = @ivp x' = A * x, x(0) ∈ X0
 
 # affine ODE: x' = Ax + Bu
 B = IntervalMatrix(hcat([1.0 ± 0.0; 1.0 ± 0.0])) # why hcat?
 U = Interval(-0.05, 0.05)
 
 # IVP(CLCCS(A, B, nothing, U), X0) TODO: remove
-interval2D_affine = @ivp x' = Ax + Bu, x(0) ∈ X0, u ∈ U
+interval2D_affine = @ivp x' = A * x + Bu, x(0) ∈ X0, u ∈ U

--- a/test/models/linear/motor.md
+++ b/test/models/linear/motor.md
@@ -31,7 +31,7 @@ U = Hyperrectangle([0.23, 0.3], [0.07, 0.1])
 Next, we instantiate the continuous LTI system,
 
 ```@example motor
-S = @system(x' = Ax + Bu, u ∈ U, x ∈ Universe(8))
+S = @system(x' = A * x + Bu, u ∈ U, x ∈ Universe(8))
 
 S = ConstrainedLinearControlContinuousSystem(A, B, nothing, U);
 nothing #hide

--- a/test/models/linear5D.jl
+++ b/test/models/linear5D.jl
@@ -18,7 +18,7 @@ function linear5D_homog()
                 0 0 -1 -3 0;
                 0 0 0 0 -2]
     X0 = Hyperrectangle(; low=fill(0.9, 5), high=fill(1.1, 5))
-    prob = @ivp(x' = Ax, x(0) ∈ X0)
+    prob = @ivp(x' = A * x, x(0) ∈ X0)
     tspan = (0.0, 5.0)
     return prob, tspan
 end
@@ -40,7 +40,7 @@ function linear5D()
     U = Ball2(zeros(5), 0.01) # input domain
 
     X0 = BallInf([1.0, 0.0, 0.0, 0.0, 0.0], 0.1)
-    prob = @ivp(x' = Ax + u, x ∈ X, u ∈ U, x(0) ∈ X0) # continuous LTI system
+    prob = @ivp(x' = A * x + u, x ∈ X, u ∈ U, x(0) ∈ X0) # continuous LTI system
     tspan = (0.0, 5.0)
     return prob, tspan
 end

--- a/test/models/motor.jl
+++ b/test/models/motor.jl
@@ -31,7 +31,7 @@ function motor_homog()
     A = state_matrix_motor()
     X0 = initial_state_motor()
 
-    prob = @ivp(x' = Ax, x(0) ∈ X0) # continuous LTI system
+    prob = @ivp(x' = A * x, x(0) ∈ X0) # continuous LTI system
     tspan = (0.0, 20.0)
     return prob, tspan
 end
@@ -43,7 +43,7 @@ function motor()
     U = Hyperrectangle([0.23, 0.3], [0.07, 0.1]) # input domain
     X0 = initial_state_motor()
 
-    prob = @ivp(x' = Ax + Bu, x ∈ X, u ∈ U, x(0) ∈ X0) # continuous LTI system
+    prob = @ivp(x' = A * x + Bu, x ∈ X, u ∈ U, x(0) ∈ X0) # continuous LTI system
     tspan = (0.0, 20.0)
     return prob, tspan
 end


### PR DESCRIPTION
See https://github.com/JuliaReach/MathematicalSystems.jl/issues/330.

This PR rewrites all `x' = Ax` to `x' = A * x` so that things work again in Julia v1.12.