### PR TITLE
Fix `BFFPSV18`

### DIFF
--- a/src/Algorithms/BFFPSV18/post.jl
+++ b/src/Algorithms/BFFPSV18/post.jl
@@ -23,7 +23,7 @@ function post(alg::BFFPSV18{N,ST}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=no
 
     # decompose the initial states into a cartesian product
     # TODO add option to do the lazy decomposition
-    Xhat0 = _decompose(Ω0, column_blocks, ST)
+    Xhat0 = decompose(Ω0, column_blocks, ST)
 
     # force using sparse type for the matrix exponential
     if alg.sparse

--- a/src/Algorithms/BFFPSV18/reach_homog.jl
+++ b/src/Algorithms/BFFPSV18/reach_homog.jl
@@ -5,11 +5,29 @@
 # Set representation: Interval
 # Matrix operations: Dense
 # Invariant: No
-function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::AbstractMatrix{NM}, NSTEPS, δ,
-                               ::Universe, ST::Type{<:Interval{N}}, vars, block_indices,
-                               row_blocks, column_blocks, Δt0,
-                               viewval::Val{true}) where {NM,N}
+function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::AbstractMatrix, NSTEPS, δ,
+                               X::Universe, ST::Type{<:Interval{N}}, vars, block_indices,
+                               row_blocks::AbstractVector, column_blocks::AbstractVector, Δt0,
+                               viewval::Val{true}) where {N}
+    return _reach_homog_BFFPSV18!(F, Xhat0, Φ, NSTEPS, δ, X, ST, vars, block_indices, row_blocks,
+                                  column_blocks, Δt0, viewval)
+end
 
+# Set representation: Interval
+# Matrix operations: Sparse  (TODO currently not exploited; only defined for disambiguation)
+# Invariant: No
+function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::SparseMatrixCSC, NSTEPS, δ,
+                               X::Universe, ST::Type{<:Interval{N}}, vars, block_indices,
+                               row_blocks::AbstractVector, column_blocks::AbstractVector, Δt0,
+                               viewval::Val{true}) where {N}
+    return _reach_homog_BFFPSV18!(F, Xhat0, Φ, NSTEPS, δ, X, ST, vars, block_indices, row_blocks,
+                                  column_blocks, Δt0, viewval)
+end
+
+function _reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ, NSTEPS, δ, ::Universe,
+                                ST::Type{<:Interval{N}}, vars, block_indices,
+                                row_blocks::AbstractVector, column_blocks::AbstractVector, Δt0,
+                                viewval::Val{true}) where {N}
     # initial reach set
     Δt = (zero(N) .. δ) + Δt0
     @inbounds F[1] = SparseReachSet(CartesianProductArray(Xhat0.array[block_indices]), Δt, vars)
@@ -44,11 +62,10 @@ end
 # Set representation: Generic
 # Matrix operations: Dense
 # Invariant: No
-function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ::N,
+function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
                                ::Universe, ST, vars, block_indices,
                                row_blocks::AbstractVector{<:RBLKi},
-                               column_blocks::AbstractVector{<:CBLKj},
-                               Δt0,
+                               column_blocks::AbstractVector{<:CBLKj}, Δt0,
                                viewval::Val{true}) where {NM,MT<:AbstractMatrix{NM},N,RBLKi,CBLKj}
 
     # initial reach-set
@@ -86,13 +103,11 @@ end
 # Set representation: Generic
 # Matrix operations: Sparse
 # Invariant: No
-function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ::N,
+function reach_homog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
                                ::Universe, ST, vars, block_indices,
                                row_blocks::AbstractVector{<:RBLKi},
-                               column_blocks::AbstractVector{<:CBLKj},
-                               Δt0,
-                               viewval::Val{true}) where {NM,IM,MT<:SparseMatrixCSC{NM,IM},N,RBLKi,
-                                                          CBLKj}
+                               column_blocks::AbstractVector{<:CBLKj}, Δt0,
+                               viewval::Val{true}) where {NM,MT<:SparseMatrixCSC{NM},N,RBLKi,CBLKj}
 
     # store first element
     Δt = (zero(N) .. δ) + Δt0

--- a/src/Algorithms/BFFPSV18/reach_inhomog.jl
+++ b/src/Algorithms/BFFPSV18/reach_inhomog.jl
@@ -5,13 +5,29 @@
 # Set representation: Interval
 # Matrix operations: Dense
 # Invariant: No
-function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
-                                 ::Universe, U, ST::Type{<:Interval{N}}, vars, block_indices,
-                                 row_blocks::AbstractVector{<:RBLKi},
-                                 column_blocks::AbstractVector{<:CBLKj},
-                                 Δt0,
-                                 viewval::Val{true}) where {NM,MT<:AbstractMatrix{NM},N,RBLKi,CBLKj}
+function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::AbstractMatrix, NSTEPS, δ,
+                                 X::Universe, U, ST::Type{<:Interval{N}}, vars, block_indices,
+                                 row_blocks::AbstractVector, column_blocks::AbstractVector, Δt0,
+                                 viewval::Val{true}) where {N}
+    return _reach_inhomog_BFFPSV18!(F, Xhat0, Φ, NSTEPS, δ, X, U, ST, vars, block_indices,
+                                    row_blocks, column_blocks, Δt0, viewval)
+end
 
+# Set representation: Interval
+# Matrix operations: Sparse  (TODO currently not exploited; only defined for disambiguation)
+# Invariant: No
+function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::SparseMatrixCSC, NSTEPS, δ,
+                                 X::Universe, U, ST::Type{<:Interval{N}}, vars, block_indices,
+                                 row_blocks::AbstractVector, column_blocks::AbstractVector, Δt0,
+                                 viewval::Val{true}) where {N}
+    return _reach_inhomog_BFFPSV18!(F, Xhat0, Φ, NSTEPS, δ, X, U, ST, vars, block_indices,
+                                    row_blocks, column_blocks, Δt0, viewval)
+end
+
+function _reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ, NSTEPS, δ,
+                                  ::Universe, U, ST::Type{<:Interval{N}}, vars, block_indices,
+                                  row_blocks::AbstractVector, column_blocks::AbstractVector, Δt0,
+                                  viewval::Val{true}) where {N}
     # initial reach set
     Δt = (zero(N) .. δ) + Δt0
     @inbounds F[1] = SparseReachSet(CartesianProductArray(Xhat0.array[block_indices]), Δt, vars)
@@ -62,9 +78,8 @@ end
 function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
                                  ::Universe, U, ST, vars, block_indices,
                                  row_blocks::AbstractVector{<:RBLKi},
-                                 column_blocks::AbstractVector{<:CBLKj},
-                                 Δt0,
-                                 viewval::Val{true}) where {NM,MT<:AbstractMatrix{NM},N,RBLKi,CBLKj}
+                                 column_blocks::AbstractVector{<:CBLKj}, Δt0,
+                                 viewval::Val{true}) where {MT<:AbstractMatrix,N,RBLKi,CBLKj}
 
     # initial reach-set
     Δt = (zero(N) .. δ) + Δt0
@@ -113,13 +128,11 @@ end
 # Set representation: Generic
 # Matrix operations: Sparse
 # Invariant: No
-function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ::N,
+function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
                                  ::Universe, U, ST, vars, block_indices,
                                  row_blocks::AbstractVector{<:RBLKi},
-                                 column_blocks::AbstractVector{<:CBLKj},
-                                 Δt0,
-                                 viewval::Val{true}) where {NM,IM,MT<:SparseMatrixCSC{NM,IM},
-                                                            N,RBLKi,CBLKj}
+                                 column_blocks::AbstractVector{<:CBLKj}, Δt0,
+                                 viewval::Val{true}) where {MT<:SparseMatrixCSC,N,RBLKi,CBLKj}
     # store first element
     Δt = (zero(N) .. δ) + Δt0
     @inbounds F[1] = SparseReachSet(CartesianProductArray(Xhat0.array[block_indices]), Δt, vars)
@@ -167,11 +180,10 @@ function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NST
     return F
 end
 
-function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ::N,
+function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
                                  ::Universe, U, ST, vars, block_indices,
                                  row_blocks::AbstractVector{<:RBLKi},
-                                 column_blocks::AbstractVector{<:CBLKj},
-                                 Δt0,
+                                 column_blocks::AbstractVector{<:CBLKj}, Δt0,
                                  viewval::Val{false}) where {NM,IM,MT<:SparseMatrixCSC{NM,IM},N,
                                                              RBLKi,CBLKj}
 
@@ -231,8 +243,7 @@ end
 function reach_inhomog_BFFPSV18!(F, Xhat0::CartesianProductArray{N}, Φ::MT, NSTEPS, δ,
                                  X::LazySet, U, ST, vars, block_indices,
                                  row_blocks::AbstractVector{<:RBLKi},
-                                 column_blocks::AbstractVector{<:CBLKj},
-                                 Δt0,
+                                 column_blocks::AbstractVector{<:CBLKj}, Δt0,
                                  viewval::Val{true}) where {NM,MT<:AbstractMatrix{NM},N,RBLKi,CBLKj}
 
     # initial reach-set

--- a/test/algorithms/BFFPSV18.jl
+++ b/test/algorithms/BFFPSV18.jl
@@ -1,74 +1,100 @@
 @testset "BFFPSV18 algorithm: type constructors" begin
+    A = rand(5, 5)
+    X0 = rand(Hyperrectangle, dim=5)
+    B = rand(5, 1)
+    X = Universe(5)
+    U = rand(Hyperrectangle, dim=1)
+    ivp = @ivp(x' = A * x, x(0) ∈ X0)
+    ivpI = @ivp(x' = A * x + B * u, x(0) ∈ X0, x ∈ X, u ∈ U)
+    δ = 1e-3
+    T = 2 * δ
 
     # interval (1D) decomposition, one variable
-    alg = BFFPSV18(; δ=1e-3, setrep=Interval, vars=[2], dim=4)
+    alg = BFFPSV18(; δ=δ, setrep=Interval, vars=[2], dim=5)
     @test alg.vars == [2]
     @test alg.block_indices == [2]
     @test alg.row_blocks == [[2]]
-    @test alg.column_blocks == [[1], [2], [3], [4]]
+    @test alg.column_blocks == [[1], [2], [3], [4], [5]]
     @test setrep(alg) == Interval{Float64}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # interval (1D) decomposition, one variable, without explicitly passing Interval
-    alg = BFFPSV18(; δ=1e-3, vars=[2], dim=4)
+    alg = BFFPSV18(; δ=δ, vars=[2], dim=5)
     @test alg.vars == [2]
     @test alg.block_indices == [2]
     @test alg.row_blocks == [[2]]
-    @test alg.column_blocks == [[1], [2], [3], [4]]
+    @test alg.column_blocks == [[1], [2], [3], [4], [5]]
     @test setrep(alg) == Interval{Float64}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # interval (1D) decomposition, two variables
-    alg = BFFPSV18(; δ=1e-3, vars=[1, 4], dim=4)
+    alg = BFFPSV18(; δ=δ, vars=[1, 4], dim=5)
     @test alg.vars == [1, 4]
     @test alg.block_indices == [1, 4]
     @test alg.row_blocks == [[1], [4]]
-    @test alg.column_blocks == [[1], [2], [3], [4]]
+    @test alg.column_blocks == [[1], [2], [3], [4], [5]]
     @test setrep(alg) == Interval{Float64}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # hyperrectangle decomposition
-    alg = BFFPSV18(; δ=1e-3, setrep=Hyperrectangle, vars=[3], partition=[[1], [2, 3, 4]])
+    alg = BFFPSV18(; δ=δ, setrep=Hyperrectangle, vars=[3], partition=[[1], [2, 3, 4, 5]])
     @test alg.vars == [3]
     @test alg.block_indices == [2] # variable 3 is in the second block
-    @test alg.row_blocks == [[2, 3, 4]]
-    @test alg.column_blocks == [[1], [2, 3, 4]]
+    @test alg.row_blocks == [[2, 3, 4, 5]]
+    @test alg.column_blocks == [[1], [2, 3, 4, 5]]
     @test setrep(alg) == Hyperrectangle{Float64,Vector{Float64},Vector{Float64}}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # hyperrectangle decomposition, without explicitly passing the set type
-    alg = BFFPSV18(; δ=1e-3, vars=[3], partition=[[1], [2, 3, 4]])
+    alg = BFFPSV18(; δ=δ, vars=[3], partition=[[1], [2, 3, 4, 5]])
     @test alg.vars == [3]
     @test alg.block_indices == [2] # variable 3 is in the second block
-    @test alg.row_blocks == [[2, 3, 4]]
-    @test alg.column_blocks == [[1], [2, 3, 4]]
+    @test alg.row_blocks == [[2, 3, 4, 5]]
+    @test alg.column_blocks == [[1], [2, 3, 4, 5]]
     @test setrep(alg) == Hyperrectangle{Float64,Vector{Float64},Vector{Float64}}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # hyperrectangular decomposition with different block sizes and a single target variable
-    alg = BFFPSV18(; δ=1e-3, setrep=Hyperrectangle, vars=[25], partition=[1:24, [25], 26:48])
-    @test alg.vars == [25]
+    alg = BFFPSV18(; δ=δ, setrep=Hyperrectangle, vars=[3], partition=[1:2, 3:3, 4:5])
+    @test alg.vars == [3]
     @test alg.block_indices == [2]
-    @test alg.row_blocks == [[25]]
-    @test alg.column_blocks == [1:24, [25], 26:48]
+    @test alg.row_blocks == [3:3]
+    @test alg.column_blocks == [1:2, 3:3, 4:5]
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # hyperrectangular decomposition with different block sizes, with variables belonging to
     # different blocks
-    alg = BFFPSV18(; δ=1e-3, setrep=Hyperrectangle, vars=[25, 37, 40],
-                   partition=[1:24, [25], 26:48])
-    @test alg.vars == [25, 37, 40]
+    alg = BFFPSV18(; δ=δ, setrep=Hyperrectangle, vars=[3, 4, 5], partition=[1:2, 3:3, 4:5])
+    @test alg.vars == [3, 4, 5]
     @test alg.block_indices == [2, 3]
-    @test alg.row_blocks == [[25], 26:48]
-    @test alg.column_blocks == [1:24, [25], 26:48]
+    @test alg.row_blocks == [3:3, 4:5]
+    @test alg.column_blocks == [1:2, 3:3, 4:5]
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # hyperrectangle decomposition with different variables in the same partition
-    alg = BFFPSV18(; δ=1e-3, vars=[1, 2], partition=[1:2, 3:5])
+    alg = BFFPSV18(; δ=δ, vars=[1, 2], partition=[1:2, 3:5])
     @test alg.vars == [1, 2]
     @test alg.block_indices == [1]
     @test alg.row_blocks == [[1, 2]]
     @test alg.column_blocks == [[1, 2], [3, 4, 5]]
     @test setrep(alg) == Hyperrectangle{Float64,Vector{Float64},Vector{Float64}}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 
     # hyperrectangle decomposition with different variables in different partitions
-    alg = BFFPSV18(; δ=1e-3, vars=[1, 3], partition=[1:2, 3:5])
+    alg = BFFPSV18(; δ=δ, vars=[1, 3], partition=[1:2, 3:5])
     @test alg.vars == [1, 3]
     @test alg.block_indices == [1, 2]
     @test alg.row_blocks == [[1, 2], [3, 4, 5]]
     @test alg.column_blocks == [[1, 2], [3, 4, 5]]
     @test setrep(alg) == Hyperrectangle{Float64,Vector{Float64},Vector{Float64}}
+    sol = solve(ivp; T=T, alg=alg)
+    sol = solve(ivpI; T=T, alg=alg)
 end


### PR DESCRIPTION
This algorithm must have been broken for a long time, but we actually did not test it.
- `_decompose` did not exist.
- Some `reach_homog_BFFPSV18`/`reach_inhomog_BFFPSV18` methods were hidden by broken disambiguations.
- Mixed types in the block structure are not supported.