### PR TITLE
Show only one plot label per flowpipe/solution

### DIFF
--- a/src/Flowpipes/recipes.jl
+++ b/src/Flowpipes/recipes.jl
@@ -162,6 +162,7 @@ end
     end
     seriesalpha --> DEFAULT_ALPHA
     seriescolor --> DEFAULT_COLOR_FLOWPIPE
+    same_recipe --> true  # LazySets flag; use to show only one label
 
     @series if !(0 ∈ vars) && (setrep(list) <: AbstractSingleton)
         seriestype --> :scatter
@@ -185,6 +186,7 @@ end
     seriesalpha --> DEFAULT_ALPHA
     seriescolor --> DEFAULT_COLOR_FLOWPIPE
     seriestype --> :shape
+    same_recipe --> true  # LazySets flag; use to show only one label
 
     @series begin
         Xs = LazySet{N}[]
@@ -210,6 +212,7 @@ end
     end
     seriesalpha --> DEFAULT_ALPHA
     seriescolor --> DEFAULT_COLOR_FLOWPIPE
+    same_recipe --> true  # LazySets flag; use to show only one label
 
     fp = flowpipe(sol)
     @series if !(0 ∈ vars) && (setrep(fp) <: AbstractSingleton)
@@ -235,6 +238,7 @@ end
     seriesalpha --> DEFAULT_ALPHA
     seriescolor --> DEFAULT_COLOR_FLOWPIPE
     seriestype --> :shape
+    same_recipe --> true  # LazySets flag; use to show only one label
 
     @series begin
         fp = flowpipe(sol)
@@ -265,6 +269,7 @@ end
     seriesalpha --> DEFAULT_ALPHA
     seriescolor --> DEFAULT_COLOR_FLOWPIPE
     seriestype --> :shape
+    same_recipe --> true  # LazySets flag; use to show only one label
 
     first = true
     x = Vector{N}()


### PR DESCRIPTION
The consolidation of plot recipes in #933 lead to interpreting a `label` intended for a flowpipe/solution to be used for each individual reach set instead ([example](https://juliareach.github.io/ReachabilityAnalysis.jl/dev/generated_examples/ProductionDestruction/#Results-3)).
The reason for this behavior is the way the plot recipe is defined in LazySets. I think it is actually a mistake that we define a recipe for a vector of sets there. Recipes work automatically for vectors.
Anyway, the solution proposed here is to use a flag from that vector recipe (which was probably intended for exactly that purpose).