### PR TITLE
Complete FAQ entry on using ODE solvers with interval initial conditions

### DIFF
--- a/docs/src/man/faq.md
+++ b/docs/src/man/faq.md
@@ -284,7 +284,23 @@ DisplayAs.Text(DisplayAs.PNG(fig))  # hide
 
 ### Can I use ODE solvers with interval initial conditions?
 
-Although it is in principle possible to  ODE solvers for
+Although it is in principle possible to use ODE solvers for interval initial conditions,
+standard ODE solvers from packages like `OrdinaryDiffEq.jl` are designed to work with
+point-valued (deterministic) initial conditions. To handle sets of initial conditions,
+you have several options:
+
+1. **Ensemble simulations**: Use the ensemble capabilities (see *How can I visualize trajectories?*)
+   to simulate multiple trajectories from points sampled within the interval. This gives you
+   trajectory-based approximations but not rigorous set enclosures.
+
+2. **Reachability analysis**: Use the reachability algorithms provided by this package
+   (e.g., `GLGM06`, `TMJets`, `LGG09`) which are specifically designed to propagate sets
+   of initial conditions and compute rigorous enclosures of all reachable states. Taylor
+   model-based methods like `TMJets` employ rigorous interval arithmetic to handle interval
+   initial conditions directly while controlling the wrapping effect.
+
+For rigorous verification and safety analysis, reachability methods are preferred over
+sampling-based approaches as they provide guaranteed enclosures of all possible behaviors.
 
 ### How do I use the `@taylorize` macro?
 


### PR DESCRIPTION
## Summary
Fixes #835 by completing the incomplete FAQ entry that was cut off mid-sentence.

The FAQ question "Can I use ODE solvers with interval initial conditions?" now has a complete answer that explains:
- Standard ODE solvers work with point-valued initial conditions
- Two approaches for handling interval initial conditions:
  1. Ensemble simulations for trajectory-based approximations
  2. Reachability analysis for rigorous set enclosures
- Guidance on when to use each approach

## Changes
- Completed the truncated sentence in `docs/src/man/faq.md`
- Added comprehensive explanation with two main approaches
- Included cross-references to related FAQ sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)