### PR TITLE
Add hybrid systems introduction with bouncing ball example to docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -87,7 +87,7 @@ PARAMETRIC_SYSTEMS = ["Parametric systems" => [
 
 HYBRID_SYSTEMS = ["Hybrid systems" => [
                                        #
-                                       #"Introduction"           => "tutorials/hybrid_systems/introduction.md",
+                                       "Introduction"           => "man/hybrid.md",
                                        #"Thermostat model"       => "tutorials/hybrid_systems/thermostat.md",
                                        "Square wave oscillator" => "generated_examples/SquareWaveOscillator.md"
                                        #


### PR DESCRIPTION
## Summary
- Adds the existing `man/hybrid.md` file (containing the bouncing ball example) to the documentation structure
- The file was already present but not referenced in `make.jl`, so it wasn't appearing in the live docs

See #471

## Test plan
- [ ] Verify docs build successfully
- [ ] Check that "Hybrid systems > Introduction" appears in the docs navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)