### PR TITLE
Fix bib entry rendering by using Unicode symbols

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -99,7 +99,7 @@
   author       = {Antoine Girard and
                   Le Guernic, Colas and
                   Oded Maler},
-  editor       = {Jo{\~{a}}o P. Hespanha and
+  editor       = {João P. Hespanha and
                   Ashish Tiwari},
   title        = {Efficient Computation of Reachable Sets of Linear Time-Invariant Systems
                   with Inputs},
@@ -186,7 +186,7 @@
   title={Reachability analysis and its application to the safety assessment of autonomous cars},
   author={Althoff, Matthias},
   year={2010},
-  school={Technische Universit{\"a}t M{\"u}nchen}
+  school={Technische Universität München}
 }
 
 @article{LeGuernicG10,
@@ -216,7 +216,7 @@
 @inproceedings{FrehseGDCRLRGDM11,
   author       = {Goran Frehse and
                   Le Guernic, Colas and
-                  Alexandre Donz{\'{e}} and
+                  Alexandre Donzé and
                   Scott Cotton and
                   Rajarshi Ray and
                   Olivier Lebeltel and
@@ -240,7 +240,7 @@
 @phdthesis{Joldes11,
   author       = {Mioara Joldes},
   title        = {Rigorous Polynomial Approximations and Applications},
-  school       = {{\'{E}}cole normale sup{\'{e}}rieure de Lyon, France},
+  school       = {École normale supérieure de Lyon, France},
   year         = {2011},
   url          = {https://tel.archives-ouvertes.fr/tel-00657843}
 }
@@ -273,7 +273,7 @@
 
 @inproceedings{ChenAS13,
   author       = {Xin Chen and
-                  Erika {\'{A}}brah{\'{a}}m and
+                  Erika Ábrahám and
                   Sriram Sankaranarayanan},
   editor       = {Natasha Sharygina and
                   Helmut Veith},
@@ -415,7 +415,7 @@
   author       = {Sergiy Bogomolov and
                   Marcelo Forets and
                   Goran Frehse and
-                  Fr{\'{e}}d{\'{e}}ric Viry and
+                  Frédéric Viry and
                   Andreas Podelski and
                   Christian Schilling},
   editor       = {Maria Prandini and
@@ -467,7 +467,7 @@
 
 @inproceedings{XueFZ18,
   author       = {Bai Xue and
-                  Martin Fr{\"{a}}nzle and
+                  Martin Fränzle and
                   Naijun Zhan},
   editor       = {Maria Prandini and
                   Jyotirmoy V. Deshmukh},


### PR DESCRIPTION
This is the recommended practice for DocumenterCitations.jl.