### PR TITLE
Use appropriate time step/horizon in tests

### DIFF
--- a/test/algorithms/GLGM06.jl
+++ b/test/algorithms/GLGM06.jl
@@ -81,25 +81,25 @@ end
 @testset "GLGM06 algorithm: inhomogeneous" begin
     # five-dim inhomogeneous
     ivp, _ = linear5D()
-    sol = solve(ivp; T=5.0, alg=GLGM06(; δ=0.01))
+    sol = solve(ivp; T=5.0, alg=GLGM06(; δ=1e-3))
     @test dim(sol) == 5
     @test tspan(shift(sol, 1.0)) == tspan(sol) + 1.0
 
     # use approx model for "discrete-time" reachability
-    sol = solve(ivp; T=5.0, alg=GLGM06(; δ=0.01, approx_model=NoBloating()))
+    sol = solve(ivp; T=5.0, alg=GLGM06(; δ=1e-3, approx_model=NoBloating()))
 
     # motor model (8 dim)
     ivp, _ = motor()
 
     # dense array case
-    alg = GLGM06(; δ=1e-2)
+    alg = GLGM06(; δ=1e-3)
     sol = solve(ivp; T=20.0, alg=alg)
     RT = ReachSet{Float64,Zonotope{Float64,Vector{Float64},Matrix{Float64}}}
     @test rsetrep(sol) == RT
 
     # static case
     @ts begin
-        alg = GLGM06(; δ=1e-2, static=true, dim=8, max_order=1, ngens=8)
+        alg = GLGM06(; δ=1e-3, static=true, dim=8, max_order=1, ngens=8)
         sol = solve(ivp; T=20.0, alg=alg)
         RT = ReachSet{Float64,Zonotope{Float64,SVector{8,Float64},SMatrix{8,8,Float64,64}}}
         @test rsetrep(sol) == RT

--- a/test/continuous/solve.jl
+++ b/test/continuous/solve.jl
@@ -2,21 +2,21 @@ using StaticArrays: SArray
 using ReachabilityAnalysis: _isapprox
 
 @testset "Default continuous post-operator" begin
-    prob, dt = motor_homog()
-    sol = solve(prob; tspan=dt)
+    prob, _ = motor_homog()
+    sol = solve(prob; T=0.001)
     @test sol.alg isa GLGM06
     @test sol.alg.static == Val{false}()
     @test setrep(sol) == Zonotope{Float64,Array{Float64,1},Array{Float64,2}}
 
     # static case
-    sol = solve(prob; tspan=dt, static=true)
+    sol = solve(prob; T=0.001, static=true)
     @test sol.alg isa GLGM06
     @test sol.alg.static == Val{true}()
     @test setrep(sol) ==
           Zonotope{Float64,SArray{Tuple{8},Float64,1,8},SArray{Tuple{8,13},Float64,2,104}}
 
     # if the static kwarg is passed outside the algorithm => it is ignored
-    sol = solve(prob; tspan=dt, alg=GLGM06(; δ=1e-2), static=true)
+    sol = solve(prob; T=0.001, alg=GLGM06(; δ=1e-5), static=true)
     @test setrep(sol) == Zonotope{Float64,Array{Float64,1},Array{Float64,2}}
 end
 
@@ -135,7 +135,7 @@ end
 
 @testset "Concrete projection" begin
     prob, tspan = motor_homog()
-    sol = solve(prob; tspan=tspan, alg=GLGM06(; δ=0.01), static=false)
+    sol = solve(prob; T=0.001, alg=GLGM06(; δ=1e-5), static=false)
 
     project(sol, (1, 3))
     project(sol, [1, 3])


### PR DESCRIPTION
These models yield large overapproximations with the first-order method, and hence a much smaller time step is needed. (If not specified, the default time step is chosen such that 100 steps are taken.)