### PR TITLE
Add `TimeInterval` wrapper type (internal) 

### DIFF
--- a/src/Algorithms/A20/A20Module.jl
+++ b/src/Algorithms/A20/A20Module.jl
@@ -1,7 +1,7 @@
 module A20Module
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, NoEnclosure,
-                              ReachSet, TimeInterval, hasinput, zeroI,
+                              ReachSet, TimeInterval, hasinput, zeroT,
                               _reconvert
 using ..FirstOrderZonotopeModule: FirstOrderZonotope
 using ..Overapproximate: _convert_or_overapproximate

--- a/src/Algorithms/A20/post.jl
+++ b/src/Algorithms/A20/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::A20{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     @unpack δ, approx_model, max_order = alg
     # TODO define these options in the algorithm struct
     static = Val(get(kwargs, :static, false))

--- a/src/Algorithms/ASB07/ASB07Module.jl
+++ b/src/Algorithms/ASB07/ASB07Module.jl
@@ -1,7 +1,7 @@
 module ASB07Module
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, ReachSet,
-                              TimeInterval, compute_nsteps, hasinput, zeroI,
+                              TimeInterval, compute_nsteps, hasinput, zeroT,
                               _isdisjoint, _normalize, _reconvert
 using ..CorrectionHullModule: CorrectionHull
 using ..Overapproximate: _convert_or_overapproximate, _split,

--- a/src/Algorithms/ASB07/post.jl
+++ b/src/Algorithms/ASB07/post.jl
@@ -1,6 +1,6 @@
 # continuous post
 function post(alg::ASB07, ivp::IVP{<:AbstractContinuousSystem}, tspan;
-              Δt0::TimeInterval=zeroI, kwargs...)
+              Δt0::TimeInterval=zeroT, kwargs...)
     δ = alg.δ
 
     NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))
@@ -18,7 +18,7 @@ end
 
 # discrete post
 function post(alg::ASB07{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     @unpack δ, approx_model, max_order, reduction_method, static, recursive, dim, ngens = alg
 
     if isnothing(NSTEPS)

--- a/src/Algorithms/BFFPSV18/BFFPSV18Module.jl
+++ b/src/Algorithms/BFFPSV18/BFFPSV18Module.jl
@@ -1,7 +1,7 @@
 module BFFPSV18Module
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, SparseReachSet,
-                              TimeInterval, hasinput, zeroI, _isdisjoint
+                              TimeInterval, hasinput, zeroT, _isdisjoint
 using ..ForwardModule: Forward
 
 using IntervalArithmetic: (..)

--- a/src/Algorithms/BFFPSV18/post.jl
+++ b/src/Algorithms/BFFPSV18/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::BFFPSV18{N,ST}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N,ST}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N,ST}
     @unpack δ, approx_model, vars, block_indices,
     row_blocks, column_blocks = alg
 

--- a/src/Algorithms/BOX/BOXModule.jl
+++ b/src/Algorithms/BOX/BOXModule.jl
@@ -1,7 +1,7 @@
 module BOXModule
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, ReachSet,
-                              TimeInterval, hasinput, zeroI, _isdisjoint,
+                              TimeInterval, hasinput, zeroT, _isdisjoint,
                               _reconvert
 using ..ForwardModule: Forward
 using ..Overapproximate: _overapproximate

--- a/src/Algorithms/BOX/post.jl
+++ b/src/Algorithms/BOX/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::BOX{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     @unpack δ, approx_model, static, dim, recursive = alg
 
     if isnothing(NSTEPS)

--- a/src/Algorithms/CARLIN/CARLINModule.jl
+++ b/src/Algorithms/CARLIN/CARLINModule.jl
@@ -1,13 +1,13 @@
 module CARLINModule
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, LGG09,
-                              MixedFlowpipe, ReachSet, flowpipe, solve, tend,
-                              tspan, zeroI, _get_T
+                              MixedFlowpipe, ReachSet, flowpipe, solve, tspan,
+                              zeroI, zeroT, _get_T
 using ..ForwardModule: Forward
 
 using Base: @kwdef
 using CarlemanLinearization: build_matrix, error_bound_specabs
-using IntervalArithmetic: IntervalBox, inf, interval, mince, sup, (..)
+using IntervalArithmetic: IntervalBox, inf, mince, sup, (..)
 import IntervalArithmetic as IA
 using LazySets: AbstractHyperrectangle, BallInf, CartesianProductArray,
                 Hyperrectangle, Interval, box_approximation, dim, high, low,

--- a/src/Algorithms/CARLIN/kronecker.jl
+++ b/src/Algorithms/CARLIN/kronecker.jl
@@ -103,7 +103,7 @@ function kron_pow(H::AbstractHyperrectangle, pow::Int, algorithm=nothing)
 end
 
 function _kron_pow_explicit(H::AbstractHyperrectangle, pow::Int)
-    x = [interval(low(H, j), high(H, j)) for j in 1:dim(H)]
+    x = [IA.interval(low(H, j), high(H, j)) for j in 1:dim(H)]
     r = reduce(kron, fill(x, pow))
 
     low_r = inf.(r)
@@ -182,7 +182,7 @@ function load_kron_dynamicpolynomials()
 
             out = Vector{IA.Interval{N}}(undef, length(y))
             for (i, p) in enumerate(y)
-                aux = interval(1)
+                aux = IA.interval(1)
                 for (xj, j) in powers(p)
                     aux = aux * B[dict[xj]]^j
                 end

--- a/src/Algorithms/CARLIN/post.jl
+++ b/src/Algorithms/CARLIN/post.jl
@@ -32,7 +32,7 @@ function canonical_form(s::BlackBoxContinuousSystem)
     # differentiate
 end
 
-function post(alg::CARLIN, ivp::IVP{<:AbstractContinuousSystem}, tspan; Δt0=zeroI, kwargs...)
+function post(alg::CARLIN, ivp::IVP{<:AbstractContinuousSystem}, tspan; Δt0=zeroT, kwargs...)
     @unpack N, compress, δ, bloat, resets = alg
 
     T = _get_T(tspan; check_zero=true, check_positive=true)

--- a/src/Algorithms/FLOWSTAR/FLOWSTARModule.jl
+++ b/src/Algorithms/FLOWSTAR/FLOWSTARModule.jl
@@ -1,9 +1,9 @@
 module FLOWSTARModule
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, TimeInterval,
-                              TaylorModelReachSet, domain, tend, tstart, zeroI
+                              TaylorModelReachSet, domain, tend, tstart, zeroT
 
-using IntervalArithmetic: IntervalBox
+using IntervalArithmetic: IntervalBox, sup
 import IntervalArithmetic as IA
 using LazySets: Hyperrectangle, overapproximate
 using MathematicalSystems: AbstractContinuousSystem, BlackBoxContinuousSystem,

--- a/src/Algorithms/FLOWSTAR/post.jl
+++ b/src/Algorithms/FLOWSTAR/post.jl
@@ -1,5 +1,5 @@
 function post(alg::FLOWSTAR{ST,OT,PT,IT}, ivp::IVP{<:AbstractContinuousSystem}, timespan;
-              Δt0::TimeInterval=zeroI, kwargs...) where {ST,OT,PT,IT}
+              Δt0::TimeInterval=zeroT, kwargs...) where {ST,OT,PT,IT}
     @required Flowstar
 
     @unpack step_size, order, remainder_estimation, precondition, cutoff, precision, verbose, scheme = alg
@@ -58,7 +58,7 @@ function post(alg::FLOWSTAR{ST,OT,PT,IT}, ivp::IVP{<:AbstractContinuousSystem}, 
     for Fi in flow
         dt = domain(first(Fi))
         δt = TimeInterval(counter + dt)
-        counter += tend(dt)
+        counter += sup(dt)
         Ri = TaylorModelReachSet(Fi, δt + Δt0)
         push!(F, Ri)
     end

--- a/src/Algorithms/GLGM06/GLGM06Module.jl
+++ b/src/Algorithms/GLGM06/GLGM06Module.jl
@@ -2,7 +2,7 @@ module GLGM06Module
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, AbstractDisjointnessMethod,
                               Flowpipe, NoEnclosure, ReachSet, TimeInterval,
-                              hasinput, linear_map_minkowski_sum, zeroI,
+                              hasinput, linear_map_minkowski_sum, zeroT,
                               _isdisjoint, _reconvert
 using ..FirstOrderZonotopeModule: FirstOrderZonotope
 using ..Overapproximate: _convert_or_overapproximate

--- a/src/Algorithms/GLGM06/post.jl
+++ b/src/Algorithms/GLGM06/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::GLGM06{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     @unpack δ, approx_model, max_order, static, dim, ngens,
     preallocate, reduction_method, disjointness_method = alg
 

--- a/src/Algorithms/HLBS25/post.jl
+++ b/src/Algorithms/HLBS25/post.jl
@@ -1,6 +1,6 @@
 # continuous post
 function post(alg::HLBS25, ivp::IVP{<:AbstractContinuousSystem}, tspan;
-              Δt0::TimeInterval=zeroI, kwargs...)
+              Δt0::TimeInterval=zeroT, kwargs...)
     δ = alg.δ
     NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))
 
@@ -12,7 +12,7 @@ end
 
 # discrete post
 function post(alg::HLBS25{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     @unpack δ, approx_model, taylor_order, max_order, reduction_method, recursive = alg
 
     if isnothing(NSTEPS)

--- a/src/Algorithms/INT/INTModule.jl
+++ b/src/Algorithms/INT/INTModule.jl
@@ -1,7 +1,7 @@
 module INTModule
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, ReachSet,
-                              TimeInterval, hasinput, zeroI, _isdisjoint
+                              TimeInterval, hasinput, zeroT, _isdisjoint
 using ..ForwardModule: Forward
 
 using IntervalArithmetic: (..)

--- a/src/Algorithms/INT/post.jl
+++ b/src/Algorithms/INT/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::INT{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     n = statedim(ivp)
     n == 1 || throw(ArgumentError("this algorithm applies to one-dimensional " *
                                   "systems, but this initial-value problem is $n-dimensional"))

--- a/src/Algorithms/LGG09/LGG09Module.jl
+++ b/src/Algorithms/LGG09/LGG09Module.jl
@@ -2,7 +2,7 @@ module LGG09Module
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe,
                               TemplateReachSet, TimeInterval, VecOrTuple,
-                              hasinput, zeroI, _collect, _isdisjoint
+                              hasinput, zeroT, _collect, _isdisjoint
 using ..ForwardModule: Forward
 
 using Base: OneTo, Slice

--- a/src/Algorithms/LGG09/post.jl
+++ b/src/Algorithms/LGG09/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::LGG09{N,AM,VN,TN}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N,AM,VN,TN}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N,AM,VN,TN}
     # dimension check
     template = alg.template
     @assert statedim(ivp) == dim(template) "the problems' dimension $(statedim(ivp)) " *

--- a/src/Algorithms/ORBIT/ORBITModule.jl
+++ b/src/Algorithms/ORBIT/ORBITModule.jl
@@ -1,7 +1,7 @@
 module ORBITModule
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, ReachSet,
-                              TimeInterval, compute_nsteps, homogenize, zeroI,
+                              TimeInterval, compute_nsteps, homogenize, zeroT,
                               _normalize
 using ..DiscretizationModule: next_set
 using ..Exponentiation: _exp

--- a/src/Algorithms/ORBIT/post.jl
+++ b/src/Algorithms/ORBIT/post.jl
@@ -1,5 +1,5 @@
 function post(alg::ORBIT{N,VT,AM}, ivp::IVP{<:AbstractContinuousSystem}, tspan;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N,VT,AM}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N,VT,AM}
     @unpack δ, approx_model = alg
 
     NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))

--- a/src/Algorithms/QINT/QINTModule.jl
+++ b/src/Algorithms/QINT/QINTModule.jl
@@ -3,10 +3,10 @@ module QINTModule
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, HybridFlowpipe,
                               INT, ReachSet, StateInLocation, TimeInterval,
                               WaitingList, hasinput, state, tend, tspan, tstart,
-                              zeroI, _normalize
+                              zeroT, _normalize, _TimeInterval
 using ..ForwardModule: Forward
 
-using IntervalArithmetic: interval, mid
+using IntervalArithmetic: mid
 using LazySets: ConvexHullArray, Interval, overapproximate, set, ⊕
 using MathematicalSystems: AbstractContinuousSystem, AffineContinuousSystem,
                            IVP, initial_state, statedim

--- a/src/Algorithms/QINT/post.jl
+++ b/src/Algorithms/QINT/post.jl
@@ -1,7 +1,7 @@
 # this algorithms assumes that the initial-value problem is one-dimensional
 # TODO requires special scalar quadratic system type
 function reach_homog_QINT(alg::QINT{N}, ivp::IVP{<:AbstractContinuousSystem}, tspan;
-                          Δt0::TimeInterval=zeroI, kwargs...) where {N}
+                          Δt0::TimeInterval=zeroT, kwargs...) where {N}
     n = statedim(ivp)
     n == 1 || throw(ArgumentError("this algorithm applies to one-dimensional " *
                                   "systems, but this initial-value problem is $n-dimensional"))
@@ -31,7 +31,8 @@ function reach_homog_QINT(alg::QINT{N}, ivp::IVP{<:AbstractContinuousSystem}, ts
 
     if got_homogeneous
         # TODO consider Δt0
-        F = reach_homog_QINT(; a=a, b=b, c=c, X0=Ω0, T=T, Δ=Δ, δ=δ, θ=θ, maxiter=maxiter)
+        F = reach_homog_QINT(; a=a, b=b, c=c, X0=Ω0, T=T, Δ=_TimeInterval(Δ), δ=δ, θ=θ,
+                             maxiter=maxiter)
     else
         error("not implemented yet")
         #U = inputset(ivp_discr)

--- a/src/Algorithms/QINT/reach_homog.jl
+++ b/src/Algorithms/QINT/reach_homog.jl
@@ -27,7 +27,7 @@ function reach_homog_QINT(; a, b, c, # right-hand side: f(x) = ax^2 + bx + c
     Ftot = Vector{FT}()
 
     # initialization
-    Δti = zeroI # defines the initial time
+    Δti = zeroT # defines the initial time
     waiting_list = WaitingList([Δti], [StateInLocation(X0, 1)])
     R̄err = Interval(-θ * Δ, θ * Δ)
 
@@ -45,7 +45,7 @@ function reach_homog_QINT(; a, b, c, # right-hand side: f(x) = ax^2 + bx + c
 
         # solve linear reachability
         prob = IVP(AffineContinuousSystem(α, β), X0)
-        sol = post(INT(; δ=δ), prob, interval(0.0, Δ); Δt0=Δti)
+        sol = post(INT(; δ=δ), prob, TimeInterval(0.0, Δ); Δt0=Δti)
 
         # compute admissible linearization error
         kθ = 1 / (exp(α * Δ) - 1) * α * θ * Δ

--- a/src/Algorithms/TMJets/TMJets21a/post.jl
+++ b/src/Algorithms/TMJets/TMJets21a/post.jl
@@ -1,5 +1,5 @@
 function post(alg::TMJets21a{N}, ivp::IVP{<:AbstractContinuousSystem}, timespan;
-              Δt0::TimeInterval=zeroI,
+              Δt0::TimeInterval=zeroT,
               kwargs...) where {N}
     @unpack orderQ, orderT, abstol, maxsteps, adaptive, minabstol, absorb, disjointness = alg
 

--- a/src/Algorithms/TMJets/TMJets21b/post.jl
+++ b/src/Algorithms/TMJets/TMJets21b/post.jl
@@ -1,5 +1,5 @@
 function post(alg::TMJets21b{N}, ivp::IVP{<:AbstractContinuousSystem}, timespan;
-              Δt0::TimeInterval=zeroI,
+              Δt0::TimeInterval=zeroT,
               kwargs...) where {N}
     @unpack orderQ, orderT, abstol, maxsteps, absorb, adaptive, minabstol,
     validatesteps, ε, δ, absorb_steps, disjointness = alg

--- a/src/Algorithms/VREP/VREPModule.jl
+++ b/src/Algorithms/VREP/VREPModule.jl
@@ -1,7 +1,7 @@
 module VREPModule
 
 using ..ReachabilityAnalysis: AbstractContinuousPost, Flowpipe, ReachSet,
-                              TimeInterval, VPOLY, hasinput, zeroI, _reconvert
+                              TimeInterval, VPOLY, hasinput, zeroT, _reconvert
 using ..ForwardModule: Forward
 
 using IntervalArithmetic: (..)

--- a/src/Algorithms/VREP/post.jl
+++ b/src/Algorithms/VREP/post.jl
@@ -2,7 +2,7 @@
 
 # discrete post
 function post(alg::VREP{N}, ivp::IVP{<:AbstractDiscreteSystem}, NSTEPS=nothing;
-              Δt0::TimeInterval=zeroI, kwargs...) where {N}
+              Δt0::TimeInterval=zeroT, kwargs...) where {N}
     @unpack δ, approx_model, static, dim = alg
 
     if isnothing(NSTEPS)

--- a/src/Algorithms/linear_post.jl
+++ b/src/Algorithms/linear_post.jl
@@ -1,7 +1,7 @@
 # default continuous post for linear systems
 function post(alg::Union{A20,BFFPSV18,BOX,GLGM06,INT,LGG09,VREP},
               ivp::IVP{<:AbstractContinuousSystem}, tspan;
-              Δt0::TimeInterval=zeroI, kwargs...)
+              Δt0::TimeInterval=zeroT, kwargs...)
     δ = alg.δ
 
     NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))

--- a/src/Continuous/TimeInterval.jl
+++ b/src/Continuous/TimeInterval.jl
@@ -1,0 +1,102 @@
+struct TimeInterval{T<:Union{IA.Interval,Interval,EmptySet}}
+    i::T
+end
+
+function TimeInterval(t0::Real, t1::Real)
+    return TimeInterval(IA.interval(t0, t1))
+end
+
+const zeroT = TimeInterval(zeroI)
+
+convert(::Type{Interval}, Δt::TimeInterval{<:Interval}) = Δt.i
+convert(::Type{Interval}, Δt::TimeInterval{<:IA.Interval}) = Interval(Δt.i)
+
+convert(::Type{IA.Interval}, Δt::TimeInterval{<:Interval}) = Δt.i.dat
+convert(::Type{IA.Interval}, Δt::TimeInterval{<:IA.Interval}) = Δt.i
+
+tstart(Δt::TimeInterval{<:Interval}) = low(Δt.i, 1)
+tstart(Δt::TimeInterval{<:IA.Interval}) = inf(Δt.i)
+
+tend(Δt::TimeInterval{<:Interval}) = high(Δt.i, 1)
+tend(Δt::TimeInterval{<:IA.Interval}) = sup(Δt.i)
+
+tspan(Δt::TimeInterval) = Δt
+
+diam(Δt::TimeInterval{<:Interval}) = diameter(Δt.i)
+diam(Δt::TimeInterval{<:IA.Interval}) = IA.diam(Δt.i)
+
+isempty(Δt::TimeInterval) = isempty(Δt.i)
+
+∈(x::Real, Δt::TimeInterval) = ∈(x, Δt.i)
+
+function _isapprox(Δt::TimeInterval, Δs::TimeInterval)
+    return (tstart(Δt) ≈ tstart(Δs)) && (tend(Δt) ≈ tend(Δs))
+end
+
+@commutative function +(Δt::TimeInterval{<:Interval}, t::Real)
+    return TimeInterval(Interval(tstart(Δt) + t, tend(Δt) + t))
+end
+
+@commutative function +(Δt::TimeInterval{<:IA.Interval}, t::Real)
+    return TimeInterval(Δt.i + t)
+end
+
+function +(Δt::TimeInterval{<:Interval}, Δs::TimeInterval{<:Interval})
+    return TimeInterval(minkowski_sum(Δt.i, Δs.i))
+end
+
+@commutative function +(Δt::TimeInterval{<:IA.Interval}, Δs::TimeInterval{<:Interval})
+    return TimeInterval(Δt.i.dat + Δs.i)
+end
+
+function +(Δt::TimeInterval{<:IA.Interval}, Δs::TimeInterval{<:IA.Interval})
+    return TimeInterval(Δt.i + Δs.i)
+end
+
+function -(Δt::TimeInterval{<:Interval}, t::Real)
+    return TimeInterval(Interval(tstart(Δt) - t, tend(Δt) - t))
+end
+
+function -(Δt::TimeInterval{<:IA.Interval}, t::Real)
+    return TimeInterval(Δt.i - t)
+end
+
+function isdisjoint(Δt::TimeInterval, Δs::TimeInterval)
+    return tstart(Δt) > tend(Δs) || tstart(Δs) > tend(Δt)
+end
+
+function ⊆(Δt::TimeInterval, Δs::TimeInterval)
+    return _issubset(Δt.i, Δs.i)
+end
+
+function _issubset(x::Interval, y::Interval)
+    return ⊆(x, y)
+end
+
+@commutative function _issubset(x::IA.Interval, y::Interval)
+    return _issubset(x, y.dat)
+end
+
+function _issubset(x::IA.Interval, y::IA.Interval)
+    return ⊆(x, y)
+end
+
+function ∩(Δt::TimeInterval, Δs::TimeInterval)
+    return TimeInterval(_intersection(Δt.i, Δs.i))
+end
+
+function _intersection(x::Interval, y::Interval)
+    return intersection(x, y)
+end
+
+@commutative function _intersection(x::IA.Interval, y::Interval)
+    return _intersection(x, y.dat)
+end
+
+function _intersection(x::IA.Interval, y::IA.Interval)
+    l, h = max(inf(x), inf(y)), min(sup(x), sup(y))
+    if l > h
+        return emptyinterval()
+    end
+    return IA.interval(l, h)
+end

--- a/src/Flowpipes/Flowpipe.jl
+++ b/src/Flowpipes/Flowpipe.jl
@@ -111,22 +111,23 @@ end
 
 # evaluate a flowpipe at a given time interval: gives possibly more than one reach set
 # i.e. first and last sets and those in between them
-function (fp::Flowpipe)(dt::TimeInterval)
+function (fp::Flowpipe)(Δt::TimeInterval)
     idx = Vector{Int}()
-    α = tstart(dt)
-    β = tend(dt)
     Xk = array(fp)
     for (i, X) in enumerate(Xk)
-        if !isempty(tspan(X) ∩ dt)
+        if !isdisjoint(tspan(X), Δt)
             push!(idx, i)
         end
     end
 
     if isempty(idx)
-        throw(ArgumentError("the time interval $dt does not intersect the time span, " *
+        throw(ArgumentError("the time interval $Δt does not intersect the time span, " *
                             "$(tspan(fp)), of the given flowpipe"))
     end
     return view(Xk, idx)
+end
+function (fp::Flowpipe)(dt::IA.Interval)
+    return fp(TimeInterval(dt))
 end
 
 # concrete projection of a flowpipe along variables `vars`

--- a/src/Hybrid/constructors.jl
+++ b/src/Hybrid/constructors.jl
@@ -160,7 +160,7 @@ end
 
 # should be treated separately because IA.Interval <: Number
 function HACLD1(sys::T, rmap::MT, Tsample::N, ζ::J) where {T,MT,N,J<:IA.Interval}
-    return HACLD1(sys, rmap, Tsample, ζ, NonDeterministicSwitching())
+    return HACLD1(sys, rmap, Tsample, TimeInterval(ζ), NonDeterministicSwitching())
 end
 
 # constructor when jitter is an interval: check whether its diameter is zero or not

--- a/src/Hybrid/time_triggered.jl
+++ b/src/Hybrid/time_triggered.jl
@@ -1,15 +1,15 @@
-function _get_numsteps(Tsample, δ, ζ, ::DeterministicSwitching)
+function _get_numsteps(Tsample, δ, ζ::TimeInterval, ::DeterministicSwitching)
     αlow = Tsample / δ
     NLOW = ceil(Int, αlow)
     return NLOW, NLOW
 end
 
-function _get_numsteps(Tsample, δ, ζ, ::NonDeterministicSwitching)
-    ζ⁻ = inf(ζ)
+function _get_numsteps(Tsample, δ, ζ::TimeInterval, ::NonDeterministicSwitching)
+    ζ⁻ = tstart(ζ)
     αlow = (Tsample + ζ⁻) / δ
     NLOW = ceil(Int, αlow)
 
-    ζ⁺ = sup(ζ)
+    ζ⁺ = tend(ζ)
     αhigh = (Tsample + ζ⁺) / δ
     NHIGH = ceil(Int, αhigh)
 
@@ -27,8 +27,8 @@ function _get_max_jumps(tspan, Tsample, δ, ζ, ::DeterministicSwitching)
     return max_jumps
 end
 
-function _get_max_jumps(tspan, Tsample, δ, ζ, ::NonDeterministicSwitching)
-    ζ⁻ = inf(ζ)
+function _get_max_jumps(tspan, Tsample, δ, ζ::TimeInterval, ::NonDeterministicSwitching)
+    ζ⁻ = tstart(ζ)
     αlow = (Tsample + ζ⁻) / δ
     NLOW = ceil(Int, αlow)
     T = tend(tspan)
@@ -76,8 +76,7 @@ function solve(ivp::IVP{<:HACLD1}, args...; kwargs...)
     prob = IVP(sys, X0)
     NLOW, NHIGH = _get_numsteps(Tsample, δ, ζ, switching)
     ζint = jitter(ha)
-    ζ⁻ = inf(ζint)
-    ζ⁺ = sup(ζint)
+    ζ⁻ = tstart(ζint)
     @assert NLOW > 0 throw(ArgumentError("inconsistent choice of parameters"))
 
     # solve first flowpipe

--- a/src/Hybrid/waiting_list.jl
+++ b/src/Hybrid/waiting_list.jl
@@ -94,7 +94,7 @@ function WaitingList(array::Vector{QT}) where {ST,M,QT<:StateInLocation{ST,M}}
     return WaitingList{TimeInterval}(array)
 end
 function WaitingList{TN}(array::Vector{QT}) where {TN,ST,M,QT<:StateInLocation{ST,M}}
-    times = fill(zeroI, length(array))
+    times = fill(zeroT, length(array))
     return WaitingList(times, array)
 end
 
@@ -107,7 +107,7 @@ tspan(w::WaitingList, i) = w.times[i]
 
 # we let elem::ET be possibly different than QT, for waiting lists which mixed set representations
 @inline function Base.push!(w::WaitingList{TN,ST,M,QT}, elem::ET) where {TN,ST,M,QT,ET}
-    push!(w.times, zeroI)
+    push!(w.times, zeroT)
     push!(w.array, elem)
     return w
 end

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -36,8 +36,6 @@ using LazySets: AbstractReductionMethod, linear_map!
 # aliases for intervals
 const IM = IntervalMatrices
 import IntervalArithmetic as IA
-using IntervalArithmetic: diam
-const TimeInterval = IA.Interval{Float64}
 import TaylorModels as TM
 using TaylorModels: TaylorModel1, TaylorN, fp_rpa, shrink_wrapping!
 
@@ -55,7 +53,7 @@ import LazySets: dim, overapproximate, box_approximation, project, Projection,
                  intersection, directions, linear_map, split!, set, array,
                  constrained_dimensions
 import ReachabilityBase.Comparison: _isapprox
-import Base: *, ∈, ∩, convert, isdisjoint
+import Base: +, -, *, ∈, ∩, ⊆, convert, isdisjoint, isempty
 import LinearAlgebra: normalize
 
 import MathematicalSystems: system, statedim, initial_state
@@ -98,10 +96,6 @@ const SecondOrderSystem = Union{SOLCS,SOACS,SOCLCCS,SOCACCS}
 const NonlinearSystem = Union{BBCS,CBBCS,CBBCCS}
 const LPCS = LinearParametricContinuousSystem
 const LPDS = LinearParametricDiscreteSystem
-
-@inline function _isapprox(Δt::TimeInterval, Δs::TimeInterval)
-    return (tstart(Δt) ≈ tstart(Δs)) && (tend(Δt) ≈ tend(Δs))
-end
 
 const VecOrTuple = Union{<:AbstractVector{Int},NTuple{D,Int}} where {D}
 const VecOrTupleOrInt = Union{<:AbstractVector{Int},NTuple{D,Int},Int} where {D}

--- a/src/ReachSets/ReachSet.jl
+++ b/src/ReachSets/ReachSet.jl
@@ -59,7 +59,7 @@ end
 
 # constructor with a time point
 function ReachSet(X::ST, t::Real) where {N,ST<:LazySet{N}}
-    return ReachSet(X, interval(t))
+    return ReachSet(X, TimeInterval(IA.interval(t)))
 end
 
 #=

--- a/src/ReachSets/SparseReachSet.jl
+++ b/src/ReachSets/SparseReachSet.jl
@@ -66,5 +66,5 @@ end
 
 # constructor with a time point
 function SparseReachSet(X::ST, t::Real, vars::AbstractVector) where {N,ST<:LazySet{N}}
-    return SparseReachSet(X, interval(t), vars)
+    return SparseReachSet(X, IA.interval(t), vars)
 end

--- a/src/ReachSets/TemplateReachSet.jl
+++ b/src/ReachSets/TemplateReachSet.jl
@@ -49,7 +49,7 @@ end
 
 # constructor with a time point
 function TemplateReachSet(dirs::AbstractDirections{N}, X::LazySet, t::N) where {N}
-    return TemplateReachSet(dirs, X, interval(t))
+    return TemplateReachSet(dirs, X, IA.interval(t))
 end
 
 # abstract reachset interface

--- a/src/ReachabilityAnalysis.jl
+++ b/src/ReachabilityAnalysis.jl
@@ -5,6 +5,7 @@ module ReachabilityAnalysis
 # ===========================================================
 include("Initialization/init.jl")
 include("Initialization/exports.jl")
+include("Continuous/TimeInterval.jl")
 include("Continuous/solve.jl")
 
 # ===========================================================

--- a/test/algorithms/ORBIT.jl
+++ b/test/algorithms/ORBIT.jl
@@ -30,14 +30,15 @@ end
 
     # test number of steps
     sol = solve(prob; tspan=(0.0, 3δ), alg=ORBIT(; δ=δ))
-    @test _isapprox(tspan(sol), interval(0, 3δ))
+    @test _isapprox(tspan(sol), TimeInterval(IA.interval(0, 3δ)))
     x = sol[end]
 
-    @test _isapprox(tspan(x), interval(3δ))
+    @test _isapprox(tspan(x), TimeInterval(IA.interval(3δ)))
     @test element(set(x)) ≈ [cos(3δ), -sin(3δ)]
 
     # test time span sequence
-    @test all(_isapprox(tspan(sol[i]), interval(δ * (i - 1))) for i in eachindex(sol))
+    @test all(_isapprox(tspan(sol[i]), TimeInterval(IA.interval(δ * (i - 1))))
+              for i in eachindex(sol))
 
     # `homogenize` option
     @test_broken solve(prob; tspan=(0.0, 3δ), alg=ORBIT(; δ=δ), homogenize=true) isa

--- a/test/algorithms/TMJets.jl
+++ b/test/algorithms/TMJets.jl
@@ -1,3 +1,7 @@
+using ReachabilityAnalysis, Test
+using ReachabilityAnalysis: TimeInterval
+import IntervalArithmetic as IA
+
 @testset "TMJets algorithm (TMJets21b)" begin
     prob, tspan = vanderpol()
 
@@ -41,8 +45,8 @@ end
 
         # getter functions for a taylor model reach-set
         R = sol[1]
-        @test domain(R) == tspan(R)
-        @test diam(remainder(R)[1]) < (alg == TMJets21a ? 1e-13 : 1e-9)
+        @test TimeInterval(domain(R)) == tspan(R)
+        @test IA.diam(remainder(R)[1]) < (alg == TMJets21a ? 1e-13 : 1e-9)
         @test get_order(R) == [8]
         @test polynomial(R) isa Vector{Taylor1{TaylorN{Float64}}}
         @test expansion_point(R) ≈ [IntervalArithmetic.interval(0.0)]

--- a/test/continuous/solve.jl
+++ b/test/continuous/solve.jl
@@ -1,5 +1,5 @@
 using StaticArrays: SArray
-using ReachabilityAnalysis: _isapprox
+using ReachabilityAnalysis: TimeInterval, _isapprox
 
 @testset "Default continuous post-operator" begin
     prob, _ = motor_homog()
@@ -31,7 +31,7 @@ end
     @test set(F, length(F)) == set(F[end])
 
     # time span methods
-    @test _isapprox(tspan(sol), 0.0 .. 1.0)
+    @test _isapprox(tspan(sol), TimeInterval(0.0 .. 1.0))
     @test tstart(F) == 0.0
     @test tend(F) ≈ 1.0
     @test tstart(F[1]) == 0.0
@@ -42,15 +42,15 @@ end
     # time span for flowpipe slices
     @test tstart(F[1:3]) ≈ 0.0
     @test tend(F[1:3]) ≈ 3δ
-    @test tspan(F[1:3]) ≈ 0.0 .. 3δ
+    @test _isapprox(tspan(F[1:3]), TimeInterval(0.0 .. 3δ))
 
     @test tstart(F, 1:3) ≈ 0.0  # same, more efficient
     @test tend(F, 1:3) ≈ 3δ
-    @test tspan(F, 1:3) ≈ 0.0 .. 3δ
+    @test _isapprox(tspan(F, 1:3), TimeInterval(0.0 .. 3δ))
 
     @test tstart(sol[1:3]) ≈ 0.0
     @test tend(sol[1:3]) ≈ 3δ
-    @test tspan(sol[1:3]) ≈ 0.0 .. 3δ
+    @test _isapprox(tspan(sol[1:3]), TimeInterval(0.0 .. 3δ))
 
     # set representation
     @test setrep(F) <: Zonotope
@@ -107,7 +107,7 @@ end
 
 @testset "Solution interface: time span" begin
     p = @ivp(x' = -x, x(0) ∈ 0 .. 1)
-    Δt = 0.0 .. 2.0
+    Δt = TimeInterval(0.0 .. 2.0)
 
     # only time horizon given
     sol = solve(p; T=2.0)

--- a/test/flowpipes/flowpipes.jl
+++ b/test/flowpipes/flowpipes.jl
@@ -1,5 +1,5 @@
 using LinearAlgebra
-using ReachabilityAnalysis: _isapprox
+using ReachabilityAnalysis: TimeInterval, _isapprox
 
 @testset "Abstract flowpipe interface" begin
     prob, dt = harmonic_oscillator()
@@ -29,7 +29,7 @@ using ReachabilityAnalysis: _isapprox
     # time domain interface
     @test tstart(fp) ≈ 0.0 && dt[1] ≈ 0.0
     @test tend(fp) ≈ 20.0 && dt[2] ≈ 20.0
-    @test _isapprox(tspan(fp), 0 .. 20)
+    @test _isapprox(tspan(fp), TimeInterval(0 .. 20))
     @test vars(fp) == (1, 2)
 end
 

--- a/test/hybrid/hybrid.jl
+++ b/test/hybrid/hybrid.jl
@@ -119,37 +119,37 @@ end
     # jitter is not defined => no jitter
     A = HACLD1(idsys, idmap, Ts)
     @inferred HACLD1(idsys, idmap, Ts)
-    @test jitter(A) == 0.0 .. 0.0
+    @test jitter(A) == TimeInterval(0.0 .. 0.0)
     @test switching(A) == DeterministicSwitching
 
     # jitter is zero => no jitter
     A = HACLD1(idsys, idmap, Ts, 0.0)
     @test_broken @inferred HACLD1(idsys, idmap, Ts, 0.0)
-    @test jitter(A) == 0.0 .. 0.0
+    @test jitter(A) == TimeInterval(0.0 .. 0.0)
     @test switching(A) == DeterministicSwitching
 
     # jitter is a number => symmetric jitter, [-ζ, ζ]
     A = HACLD1(idsys, idmap, Ts, 1e-8)
     @test_broken @inferred HACLD1(idsys, idmap, Ts, 1e-8)
-    @test jitter(A) == -1e-8 .. 1e-8
+    @test jitter(A) == TimeInterval(-1e-8 .. 1e-8)
     @test switching(A) == NonDeterministicSwitching
 
     # jitter is an interval [ζ⁻, ζ⁺]
     A = HACLD1(idsys, idmap, Ts, -1e-8 .. 1e-7)
     @inferred HACLD1(idsys, idmap, Ts, -1e-8 .. 1e-7)
-    @test jitter(A) == -1e-8 .. 1e-7
+    @test jitter(A) == TimeInterval(-1e-8 .. 1e-7)
     @test switching(A) == NonDeterministicSwitching
 
     # jitter is a vector [ζ⁻, ζ⁺], it is converted to an interval
     A = HACLD1(idsys, idmap, Ts, [-1e-8, 1e-7])
     @test_broken @inferred HACLD1(idsys, idmap, Ts, [-1e-8, 1e-7])
-    @test _isapprox(jitter(A), -1e-8 .. 1e-7)
+    @test _isapprox(jitter(A), TimeInterval(-1e-8 .. 1e-7))
     @test switching(A) == NonDeterministicSwitching
 
     # jitter is a tuple (ζ⁻, ζ⁺), it is converted to an interval
     A = HACLD1(idsys, idmap, Ts, (-1e-8, 1e-7))
     @test_broken @inferred HACLD1(idsys, idmap, Ts, (-1e-8, 1e-7))
-    @test _isapprox(jitter(A), -1e-8 .. 1e-7)
+    @test _isapprox(jitter(A), TimeInterval(-1e-8 .. 1e-7))
     @test switching(A) == NonDeterministicSwitching
 end
 

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -42,11 +42,12 @@ import Aqua, ExplicitImports
                :UnionSetArray, :Universe, :VPolygon, :VPolytope, :ZeroSet,
                :Zonotope, :affine_map, :area, :center, :complement, :concretize,
                :constrained_dimensions, :constraints_list, :convex_hull,
-               :decompose, :element, :genmat, :high, :isbounded, :isbounding,
-               :low, :minkowski_sum, :ngens, :order, :radius_hyperrectangle,
-               :reduce_order, :remove_redundant_constraints!,
-               :remove_redundant_generators, :symmetric_interval_hull, :tohrep,
-               :translate, :vertices_list, :volume, :×, :ρ, :σ, :⊕,
+               :decompose, :diameter, :element, :genmat, :high, :isbounded,
+               :isbounding, :low, :minkowski_sum, :ngens, :order,
+               :radius_hyperrectangle, :reduce_order,
+               :remove_redundant_constraints!, :remove_redundant_generators,
+               :symmetric_interval_hull, :tohrep, :translate, :vertices_list,
+               :volume, :×, :ρ, :σ, :⊕,
                :Arrays,  # superficially exported from LazySets
                # due to reexporting MathematicalSystems:
                :MathematicalSystems, Symbol("@ivp"), Symbol("@map"),

--- a/test/reachsets/reachsets.jl
+++ b/test/reachsets/reachsets.jl
@@ -8,15 +8,15 @@ using TaylorModels: set_variables,
 
     # constructor with a time interval
     R = ReachSet(X, 0 .. 1)
-    @test tspan(R) == 0 .. 1
+    @test tspan(R) == TimeInterval(0 .. 1)
 
     # constructor with a time point
     R = ReachSet(X, 1.0)
-    @test tspan(R) == interval(1.0)
+    @test tspan(R) == TimeInterval(1 .. 1)
 
     # if the time is an integer, it is converted to a float
     R = ReachSet(X, 1)
-    @test tspan(R) == interval(1.0)
+    @test tspan(R) == TimeInterval(1 .. 1)
 end
 
 @testset "Reach-set support function" begin
@@ -85,7 +85,7 @@ end
     a = overapproximate(H, TaylorModelReachSet)
     b = convert(TaylorModelReachSet, H)
 
-    @test tspan(a) == tspan(b) == 0 .. 0
+    @test tspan(a) == tspan(b) == TimeInterval(0 .. 0)
     @test isequivalent(set(overapproximate(a, Hyperrectangle)), H)
     @test isequivalent(set(overapproximate(b, Hyperrectangle)), H)
 
@@ -98,7 +98,7 @@ end
     c = overapproximate(R, TaylorModelReachSet)
     d = convert(TaylorModelReachSet, R)
 
-    @test tspan(c) == tspan(d) == 0 .. 1
+    @test tspan(c) == tspan(d) == TimeInterval(0 .. 1)
     @test isequivalent(set(overapproximate(c, Hyperrectangle)), set(R))
     @test isequivalent(set(overapproximate(d, Hyperrectangle)), set(R))
 
@@ -106,7 +106,7 @@ end
     a = overapproximate(Z, TaylorModelReachSet)
     b = convert(TaylorModelReachSet, Z)
 
-    @test tspan(a) == tspan(b) == 0 .. 0
+    @test tspan(a) == tspan(b) == TimeInterval(0 .. 0)
     @test isequivalent(set(overapproximate(a, Zonotope)), Z)
     @test isequivalent(set(overapproximate(b, Zonotope)), Z)
 
@@ -114,7 +114,7 @@ end
     c = overapproximate(R, TaylorModelReachSet)
     d = convert(TaylorModelReachSet, R)
 
-    @test tspan(c) == tspan(d) == 0 .. 1
+    @test tspan(c) == tspan(d) == TimeInterval(0 .. 1)
     @test isequivalent(set(overapproximate(c, Zonotope)), set(R))
     @test isequivalent(set(overapproximate(d, Zonotope)), set(R))
 
@@ -173,18 +173,18 @@ end
     # Two dimensional
     # ------------------
 
-    Z = ReachSet(rand(Zonotope), 0 .. 1)
+    Z = ReachSet(rand(Zonotope), TimeInterval(0 .. 1))
     T = overapproximate(Z, TaylorModelReachSet)
 
-    overapproximate(T, Zonotope; Δt=0.5 .. 1.0)
-    overapproximate(T, Zonotope; Δt=0.5 .. 1.0, dom=IntervalBox(0.9 .. 1.0, 2))
+    overapproximate(T, Zonotope; Δt=TimeInterval(0.5 .. 1.0))
+    overapproximate(T, Zonotope; Δt=TimeInterval(0.5 .. 1.0), dom=IntervalBox(0.9 .. 1.0, 2))
     overapproximate(T, Zonotope, 2)
     overapproximate(T, Zonotope, [2, 2])
 
     overapproximate(T, Hyperrectangle)
-    overapproximate(T, Hyperrectangle; Δt=0.5 .. 1.0)
+    overapproximate(T, Hyperrectangle; Δt=TimeInterval(0.5 .. 1.0))
 
-    overapproximate(T, Hyperrectangle; Δt=0.5 .. 1.0, dom=IntervalBox(0.9 .. 1.0, 2))
+    overapproximate(T, Hyperrectangle; Δt=TimeInterval(0.5 .. 1.0), dom=IntervalBox(0.9 .. 1.0, 2))
 
     # One dimensional
     # ------------------
@@ -192,14 +192,14 @@ end
     T = overapproximate(Z, TaylorModelReachSet)
 
     overapproximate(T, Zonotope)
-    overapproximate(T, Zonotope; Δt=0.5 .. 1.0)
-    overapproximate(T, Zonotope; Δt=0.5 .. 1.0, dom=IntervalBox(0.9 .. 1.0, 1))
-    overapproximate(T, Zonotope; Δt=0.5 .. 1.0, dom=0.9 .. 1.0)
+    overapproximate(T, Zonotope; Δt=TimeInterval(0.5 .. 1.0))
+    overapproximate(T, Zonotope; Δt=TimeInterval(0.5 .. 1.0), dom=IntervalBox(0.9 .. 1.0, 1))
+    overapproximate(T, Zonotope; Δt=TimeInterval(0.5 .. 1.0), dom=0.9 .. 1.0)
     overapproximate(T, Zonotope, 2)
     overapproximate(T, Zonotope, [2])
 
     overapproximate(T, Hyperrectangle)
-    overapproximate(T, Hyperrectangle; Δt=0.5 .. 1.0)
-    overapproximate(T, Hyperrectangle; Δt=0.5 .. 1.0, dom=IntervalBox(0.9 .. 1.0, 1))
-    overapproximate(T, Hyperrectangle; Δt=0.5 .. 1.0, dom=IntervalBox(0.9 .. 1.0, 1))
+    overapproximate(T, Hyperrectangle; Δt=TimeInterval(0.5 .. 1.0))
+    overapproximate(T, Hyperrectangle; Δt=TimeInterval(0.5 .. 1.0), dom=IntervalBox(0.9 .. 1.0, 1))
+    overapproximate(T, Hyperrectangle; Δt=TimeInterval(0.5 .. 1.0), dom=IntervalBox(0.9 .. 1.0, 1))
 end


### PR DESCRIPTION
This turned out to be a bigger changeset. I am not 100% sure we want to use it.

Reminder: the motivation is that `const TimeInterval = IA.Interval` will soon not work anymore because we use it in two ways:
1. as a type annotation in methods
2. as a constructor

With new IntervalArithmetic versions,  `IA.Interval` cannot be used as a constructor anymore.

The alternative currently applied in #954 is to introduce another function name `TimeIntervalC` that can be used as a constructor.