### PR TITLE
Consistent notation `E⁺`/`E⁻`

### DIFF
--- a/src/Discretization/ApplySetops.jl
+++ b/src/Discretization/ApplySetops.jl
@@ -39,33 +39,33 @@ function _apply_setops(X::ConvexHull{N,AT,MS}, ::Val{:vrep},
     n = dim(X)
     VT = n == 2 ? VPolygon : VPolytope
 
-    # CH(A, B) := CH(X₀, ΦX₀ ⊕ E₊)
+    # CH(A, B) := CH(X₀, ΦX₀ ⊕ E⁺)
     A = X.X
     B = X.Y
     X₀ = convert(VT, A)
 
     if n == 2
         ΦX₀ = convert(VT, B.X)
-        E₊ = convert(VT, B.Y)
-        out = convex_hull(X₀, minkowski_sum(ΦX₀, E₊))
+        E⁺ = convert(VT, B.Y)
+        out = convex_hull(X₀, minkowski_sum(ΦX₀, E⁺))
     else
         # generic conversion to VPolytope is missing, see LazySets#2467
         ΦX₀ = VPolytope(vertices_list(B.X; prune=false))
-        E₊ = convert(VT, B.Y)
-        aux = minkowski_sum(ΦX₀, E₊; apply_convex_hull=false)
+        E⁺ = convert(VT, B.Y)
+        aux = minkowski_sum(ΦX₀, E⁺; apply_convex_hull=false)
         out = convex_hull(X₀, aux; backend=backend)
     end
 
     return out
 end
 
-# give X = CH(X₀, ΦX₀ ⊕ E₊), return a zonotope overapproximation
+# give X = CH(X₀, ΦX₀ ⊕ E⁺), return a zonotope overapproximation
 function _apply_setops(X::ConvexHull{N,AT,MS}, ::Val{:zono},
                        backend=nothing) where {N,
                                                AT<:AbstractZonotope{N},
                                                LM<:LinearMap{N,AT,N},
                                                MS<:MinkowskiSum{N,LM}}
-    # CH(A, B) := CH(X₀, ΦX₀ ⊕ E₊)
+    # CH(A, B) := CH(X₀, ΦX₀ ⊕ E⁺)
     A = X.X
     B = X.Y
     return overapproximate(ConvexHull(A, concretize(B)), Zonotope)

--- a/src/Discretization/ForwardBackwardModule.jl
+++ b/src/Discretization/ForwardBackwardModule.jl
@@ -72,14 +72,14 @@ function discretize(ivp::IVP{<:CLCS,<:LazySet}, δ, alg::ForwardBackward)
     P2A_abs = Φ₂(A_abs, δ, alg.exp, alg.inv, Φcache)
 
     A² = A * A
-    E₊ = sih(P2A_abs * sih(A² * X0, alg.sih), alg.sih)
-    E₋ = sih(P2A_abs * sih((A² * Φ) * X0, alg.sih), alg.sih)
+    E⁺ = sih(P2A_abs * sih(A² * X0, alg.sih), alg.sih)
+    E⁻ = sih(P2A_abs * sih((A² * Φ) * X0, alg.sih), alg.sih)
 
     n = size(A, 1)
     Eψ = ZeroSet(n)
     U = ZeroSet(n)
     Φᵀ = transpose(Φ)
-    Ω0 = ContCH(δ, Φᵀ, X0, U, E₊, E₋, Eψ, get_solver(alg))
+    Ω0 = ContCH(δ, Φᵀ, X0, U, E⁺, E⁻, Eψ, get_solver(alg))
 
     # post-processing the lazy set
     Ω0 = _apply_setops(Ω0, alg)
@@ -104,13 +104,13 @@ function discretize(ivp::IVP{<:CLCCS,<:LazySet}, δ, alg::ForwardBackward)
     P2A_abs = Φ₂(A_abs, δ, alg.exp, alg.inv, Φcache)
 
     A² = A * A
-    E₊ = sih(P2A_abs * sih(A² * X0, alg.sih), alg.sih)
-    E₋ = sih(P2A_abs * sih((A² * Φ) * X0, alg.sih), alg.sih)
+    E⁺ = sih(P2A_abs * sih(A² * X0, alg.sih), alg.sih)
+    E⁻ = sih(P2A_abs * sih((A² * Φ) * X0, alg.sih), alg.sih)
     Eψ = sih(P2A_abs * sih(A * U, alg.sih), alg.sih)
 
     Ud = δ * U ⊕ Eψ
     Φᵀ = transpose(Φ)
-    Ω0 = ContCH(δ, Φᵀ, X0, U, E₊, E₋, Eψ, get_solver(alg))
+    Ω0 = ContCH(δ, Φᵀ, X0, U, E⁺, E⁻, Eψ, get_solver(alg))
 
     # post-processing the lazy set
     Ω0 = _apply_setops(Ω0, alg)
@@ -128,15 +128,15 @@ mutable struct ContCH{N,MT,ST,UT,EPT,EMT,EST,OT} <: LazySet{N}
     Φᵀ::MT
     X0::ST
     U::UT
-    E₊::EPT
-    E₋::EMT
+    E⁺::EPT
+    E⁻::EMT
     Eψ::EST
     solver::OT
 end
 
 # constructor without solver specified
-function ContCH(δ, Φᵀ, X0, U, E₊, E₋, Eψ; solver=nothing)
-    return ContCH(δ, Φᵀ, X0, U, E₊, E₋, Eψ, solver)
+function ContCH(δ, Φᵀ, X0, U, E⁺, E⁻, Eψ; solver=nothing)
+    return ContCH(δ, Φᵀ, X0, U, E⁺, E⁻, Eψ, solver)
 end
 
 function LazySets.dim(X::ContCH)
@@ -180,7 +180,7 @@ function load_forwardbackward_discretization()
         using .JuMP: Model, set_silent, register, optimize!, objective_value
 
         function LazySets.ρ(d::AbstractVector, X::ContCH)
-            @unpack δ, Φᵀ, X0, U, E₊, E₋, Eψ, solver = X
+            @unpack δ, Φᵀ, X0, U, E⁺, E⁻, Eψ, solver = X
 
             !has_solver(X) && throw(ArgumentError("the optimization solver should be specified"))
 
@@ -189,10 +189,10 @@ function load_forwardbackward_discretization()
 
             JuMP.@variable(model, 0 <= λ <= 1)
 
-            e₊ = _get_e(d, E₊)
-            e₋ = _get_e(d, E₋)
+            E⁺ = _get_e(d, E⁺)
+            E⁻ = _get_e(d, E⁻)
 
-            _ω(λ) = ω(λ, d, Φᵀ, X0, U, Eψ, δ, e₊, e₋)
+            _ω(λ) = ω(λ, d, Φᵀ, X0, U, Eψ, δ, E⁺, E⁻)
             register(model, :_ω, 1, _ω; autodiff=true)
 
             JuMP.@NLobjective(model, Max, _ω(λ))

--- a/src/Discretization/ForwardModule.jl
+++ b/src/Discretization/ForwardModule.jl
@@ -91,9 +91,9 @@ function discretize(ivp::IVP{<:CLCS,<:LazySet}, δ, alg::Forward)
     A_abs = elementwise_abs(A)
     Φcache = A == A_abs ? Φ : nothing
     P2A_abs = Φ₂(A_abs, δ, alg.exp, alg.inv, Φcache)
-    E₊ = sih(P2A_abs * sih((A * A) * X0, alg.sih), alg.sih)
+    E⁺ = sih(P2A_abs * sih((A * A) * X0, alg.sih), alg.sih)
 
-    Ω0 = ConvexHull(X0, Φ * X0 ⊕ E₊)
+    Ω0 = ConvexHull(X0, Φ * X0 ⊕ E⁺)
     Ω0 = _apply_setops(Ω0, alg)
 
     X = stateset(ivp)


### PR DESCRIPTION
The code had multiple occurrences of `E⁺`/`E⁻` and `E₊`/`E₋`. This PR uses the superscript version (which is used in the paper) everywhere.