### PR TITLE
Add simple RK4 simulation for continuous systems

### DIFF
--- a/src/Continuous/simulation.jl
+++ b/src/Continuous/simulation.jl
@@ -1,0 +1,96 @@
+const DEFAULT_TRAJECTORIES = 10
+
+struct FixedStepSequence{N}
+    F::Vector{Vector{N}}
+    δ::N
+    Δ0::N
+end
+
+struct RungeKutta
+    order::Int
+    δ::Float64
+
+    function RungeKutta(order=4, δ=1e-3)
+        if order != 4
+            throw(ArgumentError("currently, only order 4 is supported"))
+        end
+        return new(order, δ)
+    end
+end
+
+_default_simulation_algorithm() = RungeKutta()
+
+function _solve_ensemble(ivp::IVP, alg::RungeKutta=_default_simulation_algorithm(),
+                         args...; initial_states=nothing, kwargs...)
+    field = VectorField(ivp)
+
+    # get time span
+    dt = _get_tspan(args...; kwargs...)
+    Δ0 = tstart(dt)
+    if iszero(Δ0)
+        Δ0 = zero(Δ0)  # fix `-0.0`
+    end
+    T = tend(dt) - tstart(dt)
+    δ = alg.δ
+    r = range(zero(δ); stop=T, step=δ)
+    order = Val(alg.order)
+
+    if isnothing(initial_states)
+        # sample initial states from X0
+        trajectories = get(kwargs, :trajectories, DEFAULT_TRAJECTORIES)
+        initial_states = _sample_initial(initial_state(ivp), trajectories; kwargs...)
+        # number of trajectories may increase if vertices got included, so overwrite below
+    end
+    trajectories = length(initial_states)
+
+    N = Float64
+    result = Vector{FixedStepSequence{N}}(undef, trajectories)
+    @inbounds for i in 1:trajectories
+        sequence = rk(field, initial_states[i], order, r)
+        result[i] = FixedStepSequence(sequence, δ, Δ0)
+    end
+
+    return result
+end
+
+function _sample_initial(X0, trajectories; kwargs...)
+    sampler = get(kwargs, :sampler, LazySets._default_sampler(X0))
+    rng = get(kwargs, :rng, GLOBAL_RNG)
+    seed = get(kwargs, :seed, nothing)
+    include_vertices = get(kwargs, :include_vertices, false)
+    return sample(X0, trajectories; sampler=sampler, rng=rng,
+                  seed=seed, include_vertices=include_vertices)
+end
+
+# Runge-Kutta method of order 4 with arbitrary but fixed steps
+function rk(f, x0, order::Val{4}, steps::AbstractVector)
+    x = x0
+    results = Vector{typeof(x0)}(undef, length(steps))
+    t0 = zero(eltype(steps))
+    for (i, ti) in enumerate(steps)
+        if i > 1
+            δ = ti - t0
+            δ_half = δ / 2
+            k1 = f(x)
+            k2 = f(x + k1 * δ_half)
+            k3 = f(x + k2 * δ_half)
+            k4 = f(x + k3 * δ)
+            x += 1 / 6 * δ * (k1 + 2 * k2 + 2 * k3 + k4)
+        end
+        t0 = ti
+        results[i] = copy(x)
+    end
+    return results
+end
+
+# # Runge-Kutta method with a step bound
+# function rk(f, x0, δ, order, k::Integer)
+#     r = range(zero(δ); step=δ, length=(k + 1))
+#     return rk(f, x0, order, r)
+# end
+
+# # Runge-Kutta method with a time bound
+# function rk(f, x0, δ, order, T::Real)
+#     r = range(zero(δ); stop=T, step=δ)
+#     return rk(f, x0, order, r)
+# end

--- a/src/Continuous/solve.jl
+++ b/src/Continuous/solve.jl
@@ -68,7 +68,8 @@ function solve(ivp::IVP{<:AbstractContinuousSystem_}, args...; kwargs...)
     dict = Dict{Symbol,Any}(:ensemble => nothing)
     if got_ensemble
         @required OrdinaryDiffEq
-        ensemble_sol = _solve_ensemble(ivp, args...; kwargs...)
+        trajectories_alg= get(kwargs, :trajectories_alg, _default_simulation_algorithm())
+        ensemble_sol = _solve_ensemble(ivp, trajectories_alg, args...; kwargs...)
         dict[:ensemble] = ensemble_sol
     end
 

--- a/src/Continuous/solve.jl
+++ b/src/Continuous/solve.jl
@@ -67,7 +67,6 @@ function solve(ivp::IVP{<:AbstractContinuousSystem_}, args...; kwargs...)
     got_ensemble = get(kwargs, :ensemble, false)
     dict = Dict{Symbol,Any}(:ensemble => nothing)
     if got_ensemble
-        @required OrdinaryDiffEq
         trajectories_alg= get(kwargs, :trajectories_alg, _default_simulation_algorithm())
         ensemble_sol = _solve_ensemble(ivp, trajectories_alg, args...; kwargs...)
         dict[:ensemble] = ensemble_sol

--- a/src/Flowpipes/recipes.jl
+++ b/src/Flowpipes/recipes.jl
@@ -352,3 +352,30 @@ end
     end
     return x, y
 end
+
+# one trajectory
+@recipe function plot_trajectory(sim::FixedStepSequence; vars=nothing)
+    _check_vars(vars)
+    return _get_simulation_data(sim, vars)
+end
+
+# vector of trajectories
+@recipe function plot_trajectories(sims::AbstractVector{<:FixedStepSequence}; vars=nothing)
+    _check_vars(vars)
+    @series [_get_simulation_data(sim, vars) for sim in sims]
+end
+
+function _get_simulation_data(sim, vars)
+    x = _get_simulation_data_1D(sim, vars[1])
+    y = _get_simulation_data_1D(sim, vars[2])
+    return (x, y)
+end
+
+function _get_simulation_data_1D(sim, var)
+    if var == 0
+        data = [sim.Δ0 + (i - 1) * sim.δ for i in eachindex(sim.F)]
+    else
+        data = [x[var] for x in sim.F]
+    end
+    return data
+end

--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -8,6 +8,7 @@ using RecipesBase: @recipe, @series
 using Reexport: @reexport
 using SparseArrays: SparseMatrixCSC, SparseVector, sparsevec, spzeros
 using StaticArrays: MMatrix, SMatrix, SVector
+using Random: GLOBAL_RNG, shuffle!
 
 # the reexport macro ensures that the names exported by the following libraries
 # are made available after loading ReachabilityAnalysis

--- a/src/Initialization/init_OrdinaryDiffEq.jl
+++ b/src/Initialization/init_OrdinaryDiffEq.jl
@@ -1,8 +1,5 @@
 import .OrdinaryDiffEq as ODE
 using .OrdinaryDiffEq.SciMLBase: AbstractODEAlgorithm
-import Random
-
-const DEFAULT_TRAJECTORIES = 10
 
 # extend the solve API for initial-value problems
 
@@ -10,8 +7,10 @@ const DEFAULT_TRAJECTORIES = 10
 # Continuous system
 # =====================================
 
+# Note: this is a method invalidation
 _default_simulation_algorithm() = ODE.Tsit5()
 
+# Note: this is a method invalidation
 function _solve_ensemble(ivp::IVP,
                          trajectories_alg::AbstractODEAlgorithm=_default_simulation_algorithm(),
                          args...; ensemble_alg=ODE.EnsembleThreads(), inplace=true,
@@ -61,15 +60,6 @@ function _solve_ensemble(ivp::IVP,
                            abstol=abstol, dtmax=dtmax, callback=callback)
     end
     return result
-end
-
-function _sample_initial(X0, trajectories; kwargs...)
-    sampler = get(kwargs, :sampler, LazySets._default_sampler(X0))
-    rng = get(kwargs, :rng, Random.GLOBAL_RNG)
-    seed = get(kwargs, :seed, nothing)
-    include_vertices = get(kwargs, :include_vertices, false)
-    return sample(X0, trajectories; sampler=sampler, rng=rng,
-                  seed=seed, include_vertices=include_vertices)
 end
 
 # =====================================
@@ -248,8 +238,8 @@ function _sample_initial(ivp::IVP{<:AbstractHybridSystem,
         # with k initial regions, we collected up to `k * trajectories` many
         # samples (some regions may be empty), so we reduce to a random
         # collection of `trajectories` samples
-        rng = get(kwargs, :rng, Random.GLOBAL_RNG)
-        all_samples = Random.shuffle!(rng, all_samples)[1:trajectories]
+        rng = get(kwargs, :rng, GLOBAL_RNG)
+        all_samples = shuffle!(rng, all_samples)[1:trajectories]
     end
 
     return all_samples

--- a/src/Initialization/init_OrdinaryDiffEq.jl
+++ b/src/Initialization/init_OrdinaryDiffEq.jl
@@ -1,4 +1,5 @@
 import .OrdinaryDiffEq as ODE
+using .OrdinaryDiffEq.SciMLBase: AbstractODEAlgorithm
 import Random
 
 const DEFAULT_TRAJECTORIES = 10
@@ -9,13 +10,12 @@ const DEFAULT_TRAJECTORIES = 10
 # Continuous system
 # =====================================
 
-function _solve_ensemble(ivp::IVP, args...;
-                         trajectories_alg=ODE.Tsit5(),
-                         ensemble_alg=ODE.EnsembleThreads(),
-                         inplace=true,
-                         initial_states=nothing,
-                         kwargs...)
+_default_simulation_algorithm() = ODE.Tsit5()
 
+function _solve_ensemble(ivp::IVP,
+                         trajectories_alg::AbstractODEAlgorithm=_default_simulation_algorithm(),
+                         args...; ensemble_alg=ODE.EnsembleThreads(), inplace=true,
+                         initial_states=nothing, kwargs...)
     # get problem's vector field
     if inplace
         field = inplace_field!(ivp)

--- a/src/ReachabilityAnalysis.jl
+++ b/src/ReachabilityAnalysis.jl
@@ -31,6 +31,7 @@ include("Continuous/normalization.jl")
 include("Continuous/homogenization.jl")
 include("Continuous/linearization.jl")
 include("Continuous/setops.jl")
+include("Continuous/simulation.jl")
 
 # ===========================================================
 # Reachability solver algorithms

--- a/test/continuous/simulation.jl
+++ b/test/continuous/simulation.jl
@@ -1,0 +1,14 @@
+using ReachabilityAnalysis, Test
+using ReachabilityAnalysis: RungeKutta
+
+@testset "Simulation" begin
+    ivp, _ = exponential_1d()
+    Δt = (0.0, 0.01)
+    sol = solve(ivp; tspan=Δt, alg=BOX(; δ=0.01), ensemble=true)
+    sim = sol.ext[:ensemble];
+    @test length(sim) == 10
+    sol = solve(ivp; tspan=Δt, alg=BOX(; δ=0.01), ensemble=true,
+                trajectories_alg=RungeKutta(), trajectories=3)
+    sim2 = sol.ext[:ensemble];
+    @test length(sim) == 3
+end

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -9,12 +9,11 @@ import Aqua, ExplicitImports
                :plot_recipe, :shrink_wrapping!, :solve, :_exp_remainder,
                :correction_hull, :input_correction, :AbstractODEScheme,
                :AbstractPreconditioner, :AbstractTMOrder, :GIR05, :Slice,
-               :_DEF_MINABSTOL, :AbstractODEAlgorithm)
+               :_DEF_MINABSTOL, :AbstractODEAlgorithm, :GLOBAL_RNG)
     @test isnothing(ExplicitImports.check_all_explicit_imports_are_public(ReachabilityAnalysis;
                                                                           ignore=ignores))
     @test isnothing(ExplicitImports.check_all_explicit_imports_via_owners(ReachabilityAnalysis))
-    ignores = (:GIR05, :Slice, :_DEF_MINABSTOL, :_default_sampler, :GLOBAL_RNG,
-               :value)
+    ignores = (:GIR05, :Slice, :_DEF_MINABSTOL, :_default_sampler, :value)
     @test isnothing(ExplicitImports.check_all_qualified_accesses_are_public(ReachabilityAnalysis;
                                                                             ignore=ignores))
     @test isnothing(ExplicitImports.check_all_qualified_accesses_via_owners(ReachabilityAnalysis))

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -9,7 +9,7 @@ import Aqua, ExplicitImports
                :plot_recipe, :shrink_wrapping!, :solve, :_exp_remainder,
                :correction_hull, :input_correction, :AbstractODEScheme,
                :AbstractPreconditioner, :AbstractTMOrder, :GIR05, :Slice,
-               :_DEF_MINABSTOL)
+               :_DEF_MINABSTOL, :AbstractODEAlgorithm)
     @test isnothing(ExplicitImports.check_all_explicit_imports_are_public(ReachabilityAnalysis;
                                                                           ignore=ignores))
     @test isnothing(ExplicitImports.check_all_explicit_imports_via_owners(ReachabilityAnalysis))


### PR DESCRIPTION
This adds a RungeKutta simulation that can be used without loading `OrdinaryDiffEq`, which is a somewhat heavy dependency.

To still support the `OrdinaryDiffEq` solvers, which use a more complex interface, I had to make the algorithm (`trajectories_alg`) a positional argument in `_solve_ensemble`. This is not a breaking change because the user is not supposed to call this internal function directly (but we may consider exposing it in the future) and we internally convert the kwarg `trajectories_alg` to a positional argument.

Moreover, when loading `OrdinaryDiffEq`, the behavior is the same as before, i.e., the default algorithm will be switched internally to `Tsit5`.

The PR also includes a plot recipe.