### PR TITLE
Revise `compute_nsteps` helper function

### DIFF
--- a/src/Algorithms/ASB07/post.jl
+++ b/src/Algorithms/ASB07/post.jl
@@ -3,7 +3,7 @@ function post(alg::ASB07, ivp::IVP{<:AbstractContinuousSystem}, tspan;
               Δt0::TimeInterval=zeroT, kwargs...)
     δ = alg.δ
 
-    NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))
+    NSTEPS = compute_nsteps(δ, tspan; kwargs...)
 
     # normalize system to canonical form
     ivp_norm = _normalize(ivp)

--- a/src/Algorithms/HLBS25/post.jl
+++ b/src/Algorithms/HLBS25/post.jl
@@ -2,7 +2,8 @@
 function post(alg::HLBS25, ivp::IVP{<:AbstractContinuousSystem}, tspan;
               Δt0::TimeInterval=zeroT, kwargs...)
     δ = alg.δ
-    NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))
+
+    NSTEPS = compute_nsteps(δ, tspan; kwargs...)
 
     # discretize system
     ivp_discr = discretize(ivp, δ, alg.approx_model)

--- a/src/Algorithms/ORBIT/post.jl
+++ b/src/Algorithms/ORBIT/post.jl
@@ -2,7 +2,7 @@ function post(alg::ORBIT{N,VT,AM}, ivp::IVP{<:AbstractContinuousSystem}, tspan;
               Δt0::TimeInterval=zeroT, kwargs...) where {N,VT,AM}
     @unpack δ, approx_model = alg
 
-    NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))
+    NSTEPS = compute_nsteps(δ, tspan; kwargs...)
 
     U = inputset(ivp)
 

--- a/src/Algorithms/linear_post.jl
+++ b/src/Algorithms/linear_post.jl
@@ -4,7 +4,7 @@ function post(alg::Union{A20,BFFPSV18,BOX,GLGM06,INT,LGG09,VREP},
               Δt0::TimeInterval=zeroT, kwargs...)
     δ = alg.δ
 
-    NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))
+    NSTEPS = compute_nsteps(δ, tspan; kwargs...)
 
     # normalize system to canonical form
     ivp_norm = _normalize(ivp)

--- a/src/Continuous/solve.jl
+++ b/src/Continuous/solve.jl
@@ -281,11 +281,20 @@ function _get_T(Δt::TimeInterval; check_zero::Bool=true, check_positive::Bool=t
     return T
 end
 
-function compute_nsteps(δ, Δt)
+# this implementation avoids evaluation of `_compute_nsteps` unless needed
+function compute_nsteps(δ, tspan; kwargs...)
+    NSTEPS = get(kwargs, :NSTEPS, nothing)
+    if isnothing(NSTEPS)
+        return _compute_nsteps(δ, tspan)
+    end
+    return NSTEPS
+end
+
+function _compute_nsteps(δ, Δt)
     isempty(Δt) && return zero(δ)
     # Get time horizon from the time span imposing that it is of the form (0, T).
     T = _get_T(Δt; check_zero=true, check_positive=true)
-    return NSTEPS = ceil(Int, T / δ)
+    return ceil(Int, T / δ)
 end
 
 function _get_cpost(ivp, args...; kwargs...)


### PR DESCRIPTION
`NSTEPS = get(kwargs, :NSTEPS, compute_nsteps(δ, tspan))` always evaluates the function `compute_nsteps`. This PR only evaluates it if needed.