### PR TITLE
Fix name clash with `order`

### DIFF
--- a/src/Initialization/init.jl
+++ b/src/Initialization/init.jl
@@ -19,9 +19,10 @@ using StaticArrays: MMatrix, SMatrix, SVector
 
 # required to avoid conflicts with MathematicalSystems
 using LazySets: AffineMap, LinearMap, ResetMap
-
 # required to avoid conflicts with IntervalMatrices
 using LazySets: Interval, radius, sample, ∅, dim, scale, scale!, ⊂, matrix, isbounded
+# required to avoid conflicts with TaylorIntegration
+using LazySets: order
 # additional unexported symbols
 using LazySets: ExactSum, exact_sum, expmat, genmat_dep, genmat_indep, indexvector
 


### PR DESCRIPTION
- LazySets exports `order` and we `@reexport` LazySets.
- Since v0.18.5, TaylorIntegration also exports `order` and we `@reexport` TaylorIntegration.

That lead to a clash. This PR sets `order` to the LazySets version, which was the old behavior.

(Note that `order` is the new name of `get_order` in TaylorSeries, which is mandatory since v0.22.0. Still, I think that most users of ReachabilityAnalysis will not need that function. If they do, they need to explicitly add the module name.)